### PR TITLE
Be strict about a specific beta dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "ini": "^1.3.4",
-    "nexmo": "^1.0.0-beta-4"
+    "nexmo": "1.0.0-beta-4"
   }
 }


### PR DESCRIPTION
Has a beta dependency which is subject to API changes. Thus, be strict about the version of that dependency which the CLI references.