### PR TITLE
Fix number buying by uing NI Basic instead of advanced

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -78,7 +78,7 @@ class Request {
   numberBuyFromNumber(number, flags) {
     number = stripPlus(number);
     confirm(`Buying ${number}. This operation will charge your account.`, this.response.emitter, flags, () => {
-      this.client.instance().numberInsight.get({level:'advanced', number: number}, this.response.numberInsight((response) => {
+      this.client.instance().numberInsight.get({level:'basic', number: number}, this.response.numberInsight((response) => {
         this.client.instance().number.buy(response.country_code, number, this.response.numberBuyFromNumber.bind(this.response));
       }));
     });

--- a/tests/request.js
+++ b/tests/request.js
@@ -187,7 +187,7 @@ describe('Request', () => {
         nexmo.numberInsight = sinon.createStubInstance(NumberInsight);
         client.instance.returns(nexmo);
         request.numberBuy(null, { confirm: true, parent: { rawArgs: ['nb', '123'] } });
-        expect(nexmo.numberInsight.get).to.have.been.called;
+        expect(nexmo.numberInsight.get).to.have.been.calledWith({ level: 'basic', number: '123' });
       }));
 
       it('should handle search', sinon.test(function() {


### PR DESCRIPTION
Seems a little bug slipped in when we changed the nexmo module.