### PR TITLE
Add validation for status

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -10,6 +10,8 @@ class Validator {
       this.emitter.error(error.message);
     } else if (response['error-code'] && response['error-code'] !== '200') {
       this.emitter.error(response['error-code-label']);
+    } else if (response['status'] && response['status'] !== '0') {
+      this.emitter.error(response['status_message']);
     }
   }
 

--- a/tests/validator.js
+++ b/tests/validator.js
@@ -61,6 +61,20 @@ describe('Validator', () => {
           expect(stub).not.to.be.called;
         }));
       });
+
+      describe('due to status errors', () => {
+        it('should emit an error', sinon.test(function() {
+          let emitter = new Emitter();
+          let validator = new Validator(emitter);
+
+          let stub = this.stub(emitter, 'error');
+
+          validator.response(null, {'status' : '3', 'status_message' : 'foobar'});
+
+          expect(stub).to.be.called;
+          expect(stub).to.be.calledWith('foobar');
+        }));
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #43 

Checks if a `status` is present in the response and if it is non-0 it emmits an error.