### PR TITLE
Use 1.0.0-beta6 of nexmo. Bump version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexmo-cli",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Nexmo Command Line Interface",
   "main": "lib/request.js",
   "scripts": {
@@ -50,6 +50,6 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "ini": "^1.3.4",
-    "nexmo": "1.0.0-beta-5"
+    "nexmo": "1.0.0-beta-6"
   }
 }


### PR DESCRIPTION
VAPI 2-beta2 has been released. This means that the underlying `nexmo` library has been updated. This pull request updates the library that is used so that `nexmo-cli` can be used with VAPI 2-beta2.