### PR TITLE
Add account info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Credentials written to /home/username/.nexmorc
 
 Alias: `nexmo s`.
 
+#### Account info
+
+```
+> nexmo account
+API Key:    123
+API Secret: abc
+```
+
 #### Account balance
 
 ```

--- a/src/bin.js
+++ b/src/bin.js
@@ -33,6 +33,12 @@ commander
   .action(request.accountSetup.bind(request));
 
 commander
+  .command('account')
+  .description('Your account details')
+  .alias('a')
+  .action(request.accountInfo.bind(request));
+
+commander
   .command('balance')
   .description('Current account balance')
   .alias('b')

--- a/src/request.js
+++ b/src/request.js
@@ -8,10 +8,6 @@ class Request {
   }
   // Account
 
-  accountBalance() {
-    this.client.instance().account.checkBalance(this.response.accountBalance.bind(this.response));
-  }
-
   accountSetup(key, secret, flags) {
     this._verifyCredentials(key, secret, this.response.accountSetup(this.config, key, secret, flags).bind(this.response));
   }
@@ -19,6 +15,14 @@ class Request {
   _verifyCredentials(key, secret, callback) {
     let client = this.client.instanceWith(key, secret);
     client.account.checkBalance(callback);
+  }
+
+  accountInfo() {
+    this.response.accountInfo(this.config.read());
+  }
+
+  accountBalance() {
+    this.client.instance().account.checkBalance(this.response.accountBalance.bind(this.response));
   }
 
   // Pricing

--- a/src/response.js
+++ b/src/response.js
@@ -19,6 +19,13 @@ class Response {
     };
   }
 
+  accountInfo(ini) {
+    this.emitter.log(
+`API Key:    ${ini.credentials.api_key}
+API Secret: ${ini.credentials.api_secret}`
+    );
+  }
+
   accountBalance(error, response) {
     this.validator.response(error, response);
     this.emitter.log(

--- a/tests/request.js
+++ b/tests/request.js
@@ -47,6 +47,15 @@ describe('Request', () => {
       }));
     });
 
+    describe('.accountInfo', () => {
+      it('should read the credentials', sinon.test(function() {
+        nexmo = {};
+        request.accountInfo();
+        expect(config.read).to.have.been.called;
+        expect(response.accountInfo).to.have.been.called;
+      }));
+    });
+
     describe('.accountBalance', () => {
       it('should call nexmo.account.checkBalance', sinon.test(function() {
         nexmo = {};

--- a/tests/response.js
+++ b/tests/response.js
@@ -36,6 +36,13 @@ describe('Response', () => {
     }));
   });
 
+  describe('.accountInfo', () => {
+    it('should emit the result', sinon.test(function() {
+      response.accountInfo({credentials: { 'api_key' : '123', 'api_secret' : '234' }});
+      expect(emitter.log).to.have.been.calledWith(`API Key:    123
+API Secret: 234`);
+    }));
+  });
 
   describe('.accountBalance', () => {
     it('should validate the response and emit the result', sinon.test(function() {


### PR DESCRIPTION
Closes #63 

I was getting tired of looking up my API credentials on the dashboard or by `cat`-ing my `.nexmorc` file, so I just added a simple way to inspect my credentials as follows:

```sh
$ nexmo account
API Key:    abc123
API Secret: def345
```

Besides me scratching an itch here it is also useful for those of us using the `nexmo-cli` with local credentials (a local `.nexmorc` file). It allows you to quickly confirm what credentials you are using.