### PR TITLE
Show number in number:buy and number:cancel output

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ Buying 12069396555\. This operation will charge your account.
 
 Please type "confirm" to continue: confirm
 
-Number purchased
+Number purchased: 12069396555
 
 > nexmo number:buy 12069396555 --confirm
-Number purchased
+Number purchased: 12069396555
 ```
 
 Alias: `nexmo nb` and `nexmo numbers:buy`.
@@ -187,10 +187,10 @@ This is operation can not be reversed.
 
 Please type "confirm" to continue: confirm
 
-Number cancelled
+Number cancelled: 12069396555
 
 > nexmo number:cancel 12069396555 --confirm
-Number cancelled
+Number cancelled: 12069396555
 ```
 
 Alias: `nexmo nc` and `nexmo numbers:cancel`.

--- a/src/request.js
+++ b/src/request.js
@@ -79,7 +79,7 @@ class Request {
     number = stripPlus(number);
     confirm(`Buying ${number}. This operation will charge your account.`, this.response.emitter, flags, () => {
       this.client.instance().numberInsight.get({level:'basic', number: number}, this.response.numberInsight((response) => {
-        this.client.instance().number.buy(response.country_code, number, this.response.numberBuyFromNumber.bind(this.response));
+        this.client.instance().number.buy(response.country_code, number, this.response.numberBuyFromNumber(number).bind(this.response));
       }));
     });
   }
@@ -100,7 +100,7 @@ class Request {
   numberCancel(number, flags) {
     confirm('This operation can not be reversed.', this.response.emitter, flags, () => {
       this.client.instance().numberInsight.get({level: 'basic', number: number}, this.response.numberInsight((response) => {
-        this.client.instance().number.cancel(response.country_code, number, this.response.numberCancel.bind(this.response));
+        this.client.instance().number.cancel(response.country_code, number, this.response.numberCancel(number).bind(this.response));
       }));
     });
   }

--- a/src/response.js
+++ b/src/response.js
@@ -58,9 +58,11 @@ class Response {
     }
   }
 
-  numberBuyFromNumber(error, response) {
-    this.validator.response(error, response);
-    this.emitter.log('Number purchased');
+  numberBuyFromNumber(number) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      this.emitter.log(`Number purchased: ${number}`);
+    };
   }
 
   numberBuyFromPattern(callback) {
@@ -74,9 +76,11 @@ class Response {
     };
   }
 
-  numberCancel(error, response) {
-    this.validator.response(error, response);
-    this.emitter.log('Number cancelled');
+  numberCancel(number) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      this.emitter.log(`Number cancelled: ${number}`);
+    };
   }
 
   numberInsight(callback) {

--- a/tests/response.js
+++ b/tests/response.js
@@ -88,9 +88,9 @@ describe('Response', () => {
   describe('.numberBuyFromNumber', () => {
     it('should print the response', () => {
       let data = 'response';
-      response.numberBuyFromNumber(null, data);
+      response.numberBuyFromNumber('123')(null, data);
       expect(validator.response).to.have.been.calledWith(null, data);
-      expect(emitter.log).to.have.been.calledWith('Number purchased');
+      expect(emitter.log).to.have.been.calledWith('Number purchased: 123');
     });
   });
 
@@ -108,9 +108,9 @@ describe('Response', () => {
   describe('.numberCancel', () => {
     it('should print the response', () => {
       let data = 'response';
-      response.numberCancel(null, data);
+      response.numberCancel('123')(null, data);
       expect(validator.response).to.have.been.calledWith(null, data);
-      expect(emitter.log).to.have.been.calledWith('Number cancelled');
+      expect(emitter.log).to.have.been.calledWith('Number cancelled: 123');
     });
   });
 


### PR DESCRIPTION
Closes #62 

Shows the number in the output for the `number:buy` and `number:cancel` methods.

```sh
$ nexmo number:buy 441143597860 --confirm
Number purchased: 441143597860

$ nexmo number:cancel 441143597860 --confirm
Number cancelled: 441143597860

$ nexmo nb GB 447* --confirm
Number purchased: 441143597860
```