### PR TITLE
Return the max price for a country in the non verbose call

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -32,10 +32,19 @@ class Response {
     if (response.networks && this.emitter.amplified) {
       this.emitter.table(response.networks, ['network', 'mtPrice'], ['network', 'mtPrice']);
     } else if (response.mt) {
-      this.emitter.log(`${response.mt} EUR`);
+      let price = this._maxPrice(response);
+      this.emitter.log(`${price} EUR`);
     } else {
       this.emitter.log('No price found');
     }
+  }
+
+  _maxPrice(response) {
+    let prices = response.networks.map((network) => {
+      return parseFloat(network.mtPrice);
+    });
+    prices.push(parseFloat(response.mt));
+    return Math.max.apply(null, prices);
   }
 
   // numbers

--- a/tests/response.js
+++ b/tests/response.js
@@ -35,7 +35,7 @@ describe('Response', () => {
 
   describe('.priceSms', () => {
     it('should validate the response and emit the result', sinon.test(function() {
-      response.priceSms(null, { price: 123 });
+      response.priceSms(null, { price: '123' });
       expect(validator.response).to.have.been.called;
       expect(emitter.log).to.have.been.calledWith('123 EUR');
     }));
@@ -43,7 +43,7 @@ describe('Response', () => {
 
   describe('.priceVoice', () => {
     it('should validate the response and emit the result', sinon.test(function() {
-      response.priceVoice(null, { price: 123 });
+      response.priceVoice(null, { price: '123' });
       expect(validator.response).to.have.been.called;
       expect(emitter.log).to.have.been.calledWith('123 EUR');
     }));
@@ -51,9 +51,15 @@ describe('Response', () => {
 
   describe('.priceCountry', () => {
     it('should validate the response and emit the result', sinon.test(function() {
-      response.priceCountry(null, { mt: 123, networks: []});
+      response.priceCountry(null, { mt: '0.123', networks: []});
       expect(validator.response).to.have.been.called;
-      expect(emitter.log).to.have.been.calledWith('123 EUR');
+      expect(emitter.log).to.have.been.calledWith('0.123 EUR');
+    }));
+
+    it('should return the maximum value for a country', sinon.test(function() {
+      response.priceCountry(null, { mt: '0.123', networks: [{ mtPrice: '0.234' }]});
+      expect(validator.response).to.have.been.called;
+      expect(emitter.log).to.have.been.calledWith('0.234 EUR');
     }));
   });
 


### PR DESCRIPTION
Closes #57.

Updated `price:country` to determine the max price for a country and return that in the non verbose output. This prevents false advertising and gives people a better expectation of cost.

