### PR TITLE
Add account verification on setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ npm install nexmo-cli -g
 Then set up the CLI with your API key and secret:
 
 ```
-nexmo setup a123b c345d
+> nexmo setup a123b c345d
+Credentials written to /Users/yourname/.nexmorc
 ```
 
 This will save your credentials to `~/.nexmorc`. If you want to use different credentials per project you can pass the `--local` flag as follows:
 
 ```
-nexmo setup a123b c345d --local
+> nexmo setup a123b c345d --local
 ```
 
 This will save the config to your local folder instead.

--- a/src/client.js
+++ b/src/client.js
@@ -10,6 +10,10 @@ class Client {
     let nexmo = initialize(this.config, this.emitter);
     return nexmo;
   }
+
+  instanceWith(key, secret) {
+    return new Nexmo({apiKey: key, apiSecret: secret});
+  }
 }
 
 export default Client;
@@ -22,7 +26,7 @@ let initialize = function(config, emitter) {
     let credentials = config.read().credentials;
     nexmo = new Nexmo(
       {
-        apiKey: credentials.api_key, 
+        apiKey: credentials.api_key,
         apiSecret: credentials.api_secret
       },
       {

--- a/src/request.js
+++ b/src/request.js
@@ -13,12 +13,12 @@ class Request {
   }
 
   accountSetup(key, secret, flags) {
-    this.config.putAndSave({
-      'credentials': {
-        'api_key': key,
-        'api_secret': secret
-      }
-    }, flags.local);
+    this._verifyCredentials(key, secret, this.response.accountSetup(this.config, key, secret, flags).bind(this.response));
+  }
+
+  _verifyCredentials(key, secret, callback) {
+    let client = this.client.instanceWith(key, secret);
+    client.account.checkBalance(callback);
   }
 
   // Pricing

--- a/src/response.js
+++ b/src/response.js
@@ -7,6 +7,18 @@ class Response {
     this.validator = validator;
   }
 
+  accountSetup(config, key, secret, flags) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      config.putAndSave({
+        'credentials': {
+          'api_key': key,
+          'api_secret': secret
+        }
+      }, flags.local);
+    };
+  }
+
   accountBalance(error, response) {
     this.validator.response(error, response);
     this.emitter.log(

--- a/tests/client.js
+++ b/tests/client.js
@@ -13,7 +13,7 @@ describe('Client', () => {
   });
 
   describe('.instance', () => {
-    it('should initialize the library', sinon.test(function () {
+    it('should initialize the library of the filesystem', sinon.test(function () {
       let emitter = sinon.createStubInstance(Emitter);
       let config = sinon.createStubInstance(Config);
 
@@ -36,6 +36,18 @@ describe('Client', () => {
       let nexmo = client.instance();
 
       expect(nexmo._options.debug).to.be.true;
+    }));
+  });
+
+  describe('.instanceWith', () => {
+    it('should initialize a new library of the given credentials', sinon.test(function () {
+      let emitter = sinon.createStubInstance(Emitter);
+      let config = sinon.createStubInstance(Config);
+
+      let client = new Client(config, emitter);
+      let nexmo = client.instanceWith(123, 234);
+
+      expect(nexmo).to.be.an.instanceof(Nexmo);
     }));
   });
 });

--- a/tests/request.js
+++ b/tests/request.js
@@ -35,10 +35,15 @@ describe('Request', () => {
     });
 
     describe('.accountSetup', () => {
-      it('should call the Config', () => {
+      it('should verifiy the credentials', sinon.test(function(){
+        nexmo = {};
+        nexmo.account = sinon.createStubInstance(Account);
+        client.instanceWith.returns(nexmo);
+        response.accountSetup.returns(()=>{});
         request.accountSetup('123', 'abc', false);
-        expect(config.putAndSave).to.have.been.called;
-      });
+        expect(nexmo.account.checkBalance).to.have.been.called;
+        expect(response.accountSetup).to.have.been.called;
+      }));
     });
 
     describe('.accountBalance', () => {

--- a/tests/response.js
+++ b/tests/response.js
@@ -1,6 +1,7 @@
 import Response  from '../src/response.js';
 import Validator from '../src/validator.js';
 import Emitter   from '../src/emitter.js';
+import Config    from '../src/config.js';
 
 import chai, { expect } from 'chai';
 import sinon            from 'sinon';
@@ -24,6 +25,17 @@ describe('Response', () => {
     expect(Response).to.not.be.null;
     expect(Response.name).to.equal('Response');
   });
+
+  describe('.accountSetup', () => {
+    it('should validate the response and save the result', sinon.test(function() {
+      var config = sinon.createStubInstance(Config);
+
+      response.accountSetup(config, '123', 'abc', { local: false })(null, {});
+      expect(validator.response).to.have.been.called;
+      expect(config.putAndSave).to.have.been.called;
+    }));
+  });
+
 
   describe('.accountBalance', () => {
     it('should validate the response and emit the result', sinon.test(function() {


### PR DESCRIPTION
Closes #8 

The CLI now first makes an API call before trying to save your credentials, to ensure your credentials are correct.

```sh
> nexmo setup 123 345
Credentials written to /Users/cbetta/.nexmorc

> nexmo setup 123 ABC    
authentication failed
```