### PR TITLE
Add pagination details every table

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Alias: `nexmo pc`
 445555555555
 
 > nexmo numbers:list --verbose
+Item 1-3 of 3
+
 msisdn       | country | type       | features
 -----------------------------------------------
 31555555555  | NL      | landline   | VOICE    
@@ -222,6 +224,8 @@ asdasdas-asdd-2344-2344-asdasdasd234 | Test Application 1
 asdasdas-asdd-2344-2344-asdasdasd345 | Test Application 2
 
 > nexmo app:list --verbose
+Item 1-3 of 3
+
 id                                   | name
 ---------------------------------------------------------
 asdasdas-asdd-2344-2344-asdasdasd123 | Test Application 1

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -55,7 +55,16 @@ class Emitter {
     } else {
       this.log(message);
     }
+  }
 
+  pagination(flags, data) {
+    const page  = parseInt(flags.page || 1);
+    const size  = parseInt(flags.size || 10);
+    const total = data.count;
+    const start = size*(page-1) + 1;
+    const end   = start + size - 1;
+
+    if (this.amplified) this.log(`Item ${start}-${end} of ${total}\n`);
   }
 }
 

--- a/src/request.js
+++ b/src/request.js
@@ -44,7 +44,7 @@ class Request {
     if (flags.page) { options.index = flags.page; }
     if (flags.size) { options.size = flags.size; }
 
-    this.client.instance().number.get(options, this.response.numbersList.bind(this.response));
+    this.client.instance().number.get(options, this.response.numbersList(flags).bind(this.response));
   }
 
   numberSearch(country_code, flags) {
@@ -63,7 +63,7 @@ class Request {
       if (options.pattern.slice(-1) === '*') options.search_pattern = 0;
     }
 
-    this.client.instance().number.search(country_code, options, this.response.numberSearch.bind(this.response));
+    this.client.instance().number.search(country_code, options, this.response.numberSearch(flags).bind(this.response));
   }
 
   numberBuy(first, command) {
@@ -112,7 +112,7 @@ class Request {
     if (flags.page) { options.index = flags.page; }
     if (flags.size) { options.size = flags.size; }
 
-    this.client.instance().app.get(options, this.response.applicationsList.bind(this.response));
+    this.client.instance().app.get(options, this.response.applicationsList(flags).bind(this.response));
   }
 
   applicationCreate(name, answer_url, event_url, flags) {

--- a/src/response.js
+++ b/src/response.js
@@ -40,22 +40,28 @@ class Response {
 
   // numbers
 
-  numbersList(error, response) {
-    this.validator.response(error, response);
-    if (response.numbers && response.numbers.length > 0) {
-      this.emitter.table(response.numbers, ['msisdn'], ['msisdn', 'country', 'type', 'features', 'voiceCallbackType', 'voiceCallbackValue', 'moHttpUrl', 'voiceStatusCallbackUrl']);
-    } else {
-      this.emitter.warn('No numbers');
-    }
+  numbersList(flags) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      if (response.numbers && response.numbers.length > 0) {
+        this.emitter.pagination(flags, response);
+        this.emitter.table(response.numbers, ['msisdn'], ['msisdn', 'country', 'type', 'features', 'voiceCallbackType', 'voiceCallbackValue', 'moHttpUrl', 'voiceStatusCallbackUrl']);
+      } else {
+        this.emitter.warn('No numbers');
+      }
+    };
   }
 
-  numberSearch(error, response) {
-    this.validator.response(error, response);
-    if (response.numbers && response.numbers.length > 0) {
-      this.emitter.table(response.numbers, ['msisdn'], ['msisdn', 'country', 'cost', 'type', 'features']);
-    } else {
-      this.emitter.warn('No numbers');
-    }
+  numberSearch(flags) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      if (response.numbers && response.numbers.length > 0) {
+        this.emitter.pagination(flags, response);
+        this.emitter.table(response.numbers, ['msisdn'], ['msisdn', 'country', 'cost', 'type', 'features']);
+      } else {
+        this.emitter.warn('No numbers');
+      }
+    };
   }
 
   numberBuyFromNumber(error, response) {
@@ -88,13 +94,16 @@ class Response {
 
   // applications
 
-  applicationsList(error, response) {
-    this.validator.response(error, response);
-    if (response._embedded && response._embedded.applications && response._embedded.applications.length > 0) {
-      this.emitter.table(response._embedded.applications, ['id', 'name'], ['id', 'name']);
-    } else {
-      this.emitter.warn('No applications');
-    }
+  applicationsList(flags) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      if (response._embedded && response._embedded.applications && response._embedded.applications.length > 0) {
+        this.emitter.pagination(flags, response);
+        this.emitter.table(response._embedded.applications, ['id', 'name'], ['id', 'name']);
+      } else {
+        this.emitter.warn('No applications');
+      }
+    };
   }
 
   applicationCreate(flags) {

--- a/tests/request.js
+++ b/tests/request.js
@@ -94,6 +94,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numbersList.returns(()=>{});
         request.numbersList({});
         expect(nexmo.number.get).to.have.been.called;
       }));
@@ -102,6 +103,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numbersList.returns(()=>{});
         request.numbersList({ page: 2 });
         expect(nexmo.number.get).to.have.been.calledWith({ index: 2 });
       }));
@@ -110,6 +112,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numbersList.returns(()=>{});
         request.numbersList({ size: 25 });
         expect(nexmo.number.get).to.have.been.calledWith({ size: 25 });
       }));
@@ -120,6 +123,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', {});
         expect(nexmo.number.search).to.have.been.called;
       }));
@@ -128,6 +132,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { voice: true });
         expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['VOICE'] });
       }));
@@ -136,6 +141,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { sms: true });
         expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['SMS'] });
       }));
@@ -144,6 +150,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { sms: true, voice: true });
         expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['VOICE','SMS'] });
       }));
@@ -152,6 +159,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { page: 2 });
         expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], index: 2 });
       }));
@@ -160,6 +168,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { size: 25 });
         expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], size: 25 });
       }));
@@ -168,6 +177,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { pattern: '020'});
         expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], pattern: '020', search_pattern: 1 });
       }));
@@ -176,6 +186,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { pattern: '*020'});
         expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], pattern: '*020', search_pattern: 2 });
       }));
@@ -214,6 +225,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.app = sinon.createStubInstance(App);
         client.instance.returns(nexmo);
+        response.applicationsList.returns(()=>{});
         request.applicationsList({});
         expect(nexmo.app.get).to.have.been.called;
       }));
@@ -222,6 +234,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.app = sinon.createStubInstance(App);
         client.instance.returns(nexmo);
+        response.applicationsList.returns(()=>{});
         request.applicationsList({ page: 2 });
         expect(nexmo.app.get).to.have.been.calledWith({ index: 2 });
       }));
@@ -230,6 +243,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.app = sinon.createStubInstance(App);
         client.instance.returns(nexmo);
+        response.applicationsList.returns(()=>{});
         request.applicationsList({ size: 25 });
         expect(nexmo.app.get).to.have.been.calledWith({ size: 25 });
       }));

--- a/tests/response.js
+++ b/tests/response.js
@@ -60,13 +60,13 @@ describe('Response', () => {
   describe('.numbersList', () => {
     it('should print a list of numbers', () => {
       let data = {'count':1,'numbers':[{'country':'ES','msisdn':'34911067000','type':'landline','features':['SMS']}]};
-      response.numbersList(null, data);
+      response.numbersList({})(null, data);
       expect(validator.response).to.have.been.calledWith(null, data);
       expect(emitter.table).to.have.been.calledWith([{ country: 'ES', features: ['SMS'], msisdn: '34911067000', type: 'landline' }], ['msisdn'], ['msisdn', 'country', 'type', 'features', 'voiceCallbackType', 'voiceCallbackValue', 'moHttpUrl', 'voiceStatusCallbackUrl']);
     });
 
     it('should warn if no numbers found', () => {
-      response.numbersList(null, { numbers: []});
+      response.numbersList({})(null, { numbers: []});
       expect(emitter.warn).to.have.been.called;
     });
   });
@@ -74,13 +74,13 @@ describe('Response', () => {
   describe('.numberSearch', () => {
     it('should print a list of numbers', () => {
       let data = {'count':1,'numbers':[{'country':'ES','msisdn':'34911067000','type':'landline','features':['SMS']}]};
-      response.numberSearch(null, data);
+      response.numberSearch({})(null, data);
       expect(validator.response).to.have.been.calledWith(null, data);
       expect(emitter.table).to.have.been.calledWith([{ country: 'ES', features: ['SMS'], msisdn: '34911067000', type: 'landline' }], ['msisdn'], ['msisdn', 'country', 'cost', 'type', 'features']);
     });
 
     it('should warn if no numbers found', () => {
-      response.numberSearch(null, { numbers: []});
+      response.numberSearch({})(null, { numbers: []});
       expect(emitter.warn).to.have.been.called;
     });
   });
@@ -128,13 +128,13 @@ describe('Response', () => {
   describe('.applicationsList', () => {
     it('should print a list of application', () => {
       let data = {'_embedded':{'applications':[{'id':123}]}};
-      response.applicationsList(null, data);
+      response.applicationsList({})(null, data);
       expect(validator.response).to.have.been.calledWith(null, data);
       expect(emitter.table).to.have.been.calledWith([{'id':123}], ['id', 'name'], ['id', 'name']);
     });
 
     it('should warn if no applications found', () => {
-      response.applicationsList(null, {'_embedded':{'applications':[]}});
+      response.applicationsList({})(null, {'_embedded':{'applications':[]}});
       expect(emitter.warn).to.have.been.called;
     });
   });


### PR DESCRIPTION
Added a feature to the `number:list`, `number:search` and `application:list` commands where it now adds some extra details about the page and total number of items:

```sh
> next number:list -v
Item 1-10 of 11

msisdn       | country | type       | features  | voiceCallbackType | voiceCallbackValue | moHttpUrl | voiceStatusCallbackUrl
-----------------------------------------------------------------------------------------------------------------------------
447555555550 | GB      | landline   | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555551 | GB      | landline   | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555552 | GB      | landline   | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555553 | GB      | landline   | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555554 | GB      | landline   | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555555 | GB      | landline   | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555556 | GB      | landline   | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555557 | GB      | mobile-lvn | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555558 | GB      | mobile-lvn | VOICE,SMS | undefined         | undefined          | undefined | undefined             
447555555559 | GB      | mobile-lvn | VOICE,SMS | undefined         | undefined          | undefined | undefined  
```

Closes #50 