### PR TITLE
Add SMS sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This will save the config to your local folder instead.
 
 ## Usage
 
-[Flags](#flags) | [Account](#account) | [Pricing](#pricing) | [Numbers](#numbers) | [Applications](#applications) | [Linking](#linking) | [Insight](#insight)
+[Flags](#flags) | [Account](#account) | [Pricing](#pricing) | [Numbers](#numbers) | [SMS](#sms) | [Applications](#applications) | [Linking](#linking) | [Insight](#insight)
 
 ### Flags
 
@@ -205,6 +205,24 @@ Number updated
 ```
 
 Alias: `nexmo nu` and `nexmo numbers:update`.
+
+### SMS
+
+#### Send an SMS
+
+Send a message through Nexmo to any number. Either provide a from number, name, or leave it blank to sends as "Nexmo CLI".
+
+```
+> nexmo sms <destination_number> "Hello world!" --confirm
+Message sent to:   <destination_number>
+Remaining balance: 26.80110000 EUR
+Message price:     0.03330000 EUR
+
+> nexmo sms <from_name_or_number> <destination_number> "Hello world!" --confirm
+Message sent to:   <destination_number>
+Remaining balance: 26.80110000 EUR
+Message price:     0.03330000 EUR
+```
 
 ### Applications
 

--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ Alias: `nexmo nu` and `nexmo numbers:update`.
 Send a message through Nexmo to any number. Either provide a from number, name, or leave it blank to sends as "Nexmo CLI".
 
 ```
-> nexmo sms <destination_number> "Hello world!" --confirm
+> nexmo sms <destination_number> Hello world! --confirm
 Message sent to:   <destination_number>
 Remaining balance: 26.80110000 EUR
 Message price:     0.03330000 EUR
 
-> nexmo sms <from_name_or_number> <destination_number> "Hello world!" --confirm
+> nexmo sms  <destination_number> Hello world! --from "Acme Inc" --confirm
 Message sent to:   <destination_number>
 Remaining balance: 26.80110000 EUR
 Message price:     0.03330000 EUR

--- a/src/bin.js
+++ b/src/bin.js
@@ -467,11 +467,11 @@ commander
 // sending sms
 
 commander
-  .command('sms [from] [to] [text]')
+  .command('sms <to> <text...>')
   .option('--confirm', 'skip confirmation step and directly send the message' )
+  .option('-f, --from <from...>', 'the number or name to send the SMS message from (defaults to "Nexmo CLI")', 'Nexmo CLI')
   .description('Send an SMS')
   .action(request.sendSms.bind(request));
-
 
 // catch unknown commands
 commander

--- a/src/bin.js
+++ b/src/bin.js
@@ -464,6 +464,15 @@ commander
   })
   .action(request.priceCountry.bind(request));
 
+// sending sms
+
+commander
+  .command('sms [from] [to] [text]')
+  .option('--confirm', 'skip confirmation step and directly send the message' )
+  .description('Send an SMS')
+  .action(request.sendSms.bind(request));
+
+
 // catch unknown commands
 commander
   .command('*', null, { noHelp: true })

--- a/src/request.js
+++ b/src/request.js
@@ -67,7 +67,7 @@ class Request {
   }
 
   numberBuy(first, command) {
-    let args = command.parent.rawArgs.filter(arg => (arg.indexOf('--') == -1 && arg.indexOf('nexmo') == -1 && arg.indexOf('node') == -1));
+    let args = command.parent.rawArgs.filter(arg => (arg.indexOf('-') == -1 && arg.indexOf('nexmo') == -1 && arg.indexOf('node') == -1));
     if (args.length == 2) {
       this.numberBuyFromNumber(args[1], command);
     } else if (args.length == 3) {
@@ -223,6 +223,23 @@ class Request {
     number = stripPlus(number);
     confirm('This operation will charge your account.', this.response.emitter, flags, () => {
       this.client.instance().numberInsight.get({level: 'standard', number: number}, this.response.insightStandard.bind(this.response));
+    });
+  }
+
+  // sending messages
+
+  sendSms(first, second, third, command) {
+    let args = command.parent.rawArgs.filter(arg => (arg.indexOf('-') == -1 && arg.indexOf('nexmo') == -1 && arg.indexOf('node') == -1));
+    if (args.length == 3) {
+      this._sendSms('Nexmo CLI', first, second, command);
+    } else if (args.length == 4) {
+      this._sendSms(first, second, third, command);
+    }
+  }
+
+  _sendSms(from, to, text, flags) {
+    confirm('This operation will charge your account.', this.response.emitter, flags, () => {
+      this.client.instance().message.sendSms(from, to, text, this.response.sendSms.bind(this.response));
     });
   }
 }

--- a/src/request.js
+++ b/src/request.js
@@ -228,18 +228,9 @@ class Request {
 
   // sending messages
 
-  sendSms(first, second, third, command) {
-    let args = command.parent.rawArgs.filter(arg => (arg.indexOf('-') == -1 && arg.indexOf('nexmo') == -1 && arg.indexOf('node') == -1));
-    if (args.length == 3) {
-      this._sendSms('Nexmo CLI', first, second, command);
-    } else if (args.length == 4) {
-      this._sendSms(first, second, third, command);
-    }
-  }
-
-  _sendSms(from, to, text, flags) {
+  sendSms(to, text, flags) {
     confirm('This operation will charge your account.', this.response.emitter, flags, () => {
-      this.client.instance().message.sendSms(from, to, text, this.response.sendSms.bind(this.response));
+      this.client.instance().message.sendSms(flags.from, to, text.join(' '), this.response.sendSms.bind(this.response));
     });
   }
 }

--- a/src/response.js
+++ b/src/response.js
@@ -159,6 +159,16 @@ class Response {
     this.emitter.log(colors.red.bgWhite(`${private_key}\n`));
     this.emitter.log('WARNING: You should save this key somewhere safe and secure now, it will not be provided again.');
   }
+
+  // sending messages
+
+  sendSms(error, response) {
+    this.validator.response(error, response);
+    const message = response.messages[0];
+    this.emitter.log(`Message sent to:   ${message.to}
+Remaining balance: ${message['remaining-balance']} EUR
+Message price:     ${message['message-price']} EUR`);
+  }
 }
 
 export default Response;

--- a/tests/request.js
+++ b/tests/request.js
@@ -434,16 +434,8 @@ describe('Request', () => {
         nexmo = {};
         nexmo.message = sinon.createStubInstance(Message);
         client.instance.returns(nexmo);
-        request.sendSms('from', 'to', 'message', { confirm: true, parent: { rawArgs: ['sms', 'from', 'to', 'message'] } });
-        expect(nexmo.message.sendSms).to.have.been.calledWith('from', 'to', 'message');
-      }));
-
-      it('should allow for skipping the from name', sinon.test(function() {
-        nexmo = {};
-        nexmo.message = sinon.createStubInstance(Message);
-        client.instance.returns(nexmo);
-        request.sendSms('to', 'message', null, { confirm: true, parent: { rawArgs: ['sms', 'to', 'message'] } });
-        expect(nexmo.message.sendSms).to.have.been.calledWith('Nexmo CLI', 'to', 'message');
+        request.sendSms('to', ['Hello', 'World'], { 'from' : 'from', 'confirm' : true });
+        expect(nexmo.message.sendSms).to.have.been.calledWith('from', 'to', 'Hello World');
       }));
     });
   });

--- a/tests/request.js
+++ b/tests/request.js
@@ -3,10 +3,11 @@ import Config   from '../src/config.js';
 import Request  from '../src/request.js';
 import Response from '../src/response.js';
 
-import Account  from 'nexmo/lib/Account';
-import Number  from 'nexmo/lib/Number';
+import Account        from 'nexmo/lib/Account';
+import App            from 'nexmo/lib/App';
+import Message        from 'nexmo/lib/Message';
+import Number         from 'nexmo/lib/Number';
 import NumberInsight  from 'nexmo/lib/NumberInsight';
-import App  from 'nexmo/lib/App';
 
 import chai, { expect } from 'chai';
 import sinon      from 'sinon';
@@ -425,6 +426,24 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         request.insightStandard('4555555', { confirm: true });
         expect(nexmo.numberInsight.get).to.have.been.calledWithMatch({level:'standard'});
+      }));
+    });
+
+    describe('.sendSms', () => {
+      it('should call nexmo.message.sendSms', sinon.test(function() {
+        nexmo = {};
+        nexmo.message = sinon.createStubInstance(Message);
+        client.instance.returns(nexmo);
+        request.sendSms('from', 'to', 'message', { confirm: true, parent: { rawArgs: ['sms', 'from', 'to', 'message'] } });
+        expect(nexmo.message.sendSms).to.have.been.calledWith('from', 'to', 'message');
+      }));
+
+      it('should allow for skipping the from name', sinon.test(function() {
+        nexmo = {};
+        nexmo.message = sinon.createStubInstance(Message);
+        client.instance.returns(nexmo);
+        request.sendSms('to', 'message', null, { confirm: true, parent: { rawArgs: ['sms', 'to', 'message'] } });
+        expect(nexmo.message.sendSms).to.have.been.calledWith('Nexmo CLI', 'to', 'message');
       }));
     });
   });

--- a/tests/response.js
+++ b/tests/response.js
@@ -206,4 +206,26 @@ describe('Response', () => {
       expect(emitter.list).to.have.been.calledWith('123 | GB | Telco', data);
     });
   });
+
+  describe('.sensSms', () => {
+    it('should print the response', () => {
+      let data = { 'message-count': '1',
+                    messages: [
+                       { to: '447518397784',
+                         'message-id': '02000000E6ED9837',
+                         status: '0',
+                         'remaining-balance': '26.83440000',
+                         'message-price': '0.03330000',
+                         network: '23410'
+                       }
+                    ]
+                  };
+
+      response.sendSms(null, data);
+      expect(validator.response).to.have.been.calledWith(null, data);
+      expect(emitter.log).to.have.been.calledWith(`Message sent to:   447518397784
+Remaining balance: 26.83440000 EUR
+Message price:     0.03330000 EUR`);
+    });
+  });
 });


### PR DESCRIPTION
Adds sending of an SMS. Only implements the basics to keep things simple. It auto detects if a `from` sender has been given and if not uses `Nexmo CLI` as the from field.

```
> nexmo sms <destination_number> "Hello world!" --confirm
Message sent to:   <destination_number>
Remaining balance: 26.80110000 EUR
Message price:     0.03330000 EUR

> nexmo sms <from_name_or_number> <destination_number> "Hello world!" --confirm
Message sent to:   <destination_number>
Remaining balance: 26.80110000 EUR
Message price:     0.03330000 EUR
```

Closes #17 