### PR TITLE
Simplify number:buy and alias numbers:buy

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -70,9 +70,9 @@ commander
 // Number Buy
 commander
   .command('number:buy [number_pattern]')
-  .description('Buy a number to use for voice or SMS. If a --country_id is provided then the number_pattern is used to search for a number in the given country.')
+  .description('Buy a number to use for voice or SMS. If a --country_code is provided then the number_pattern is used to search for a number in the given country.')
   .alias('nb')
-  .option('-c, --country_id [country_id]', 'the country code')
+  .option('-c, --country_code [country_code]', 'the country code')
   .option('--confirm', 'skip confirmation step and directly buy the number' )
   .on('--help', () => {
     emitter.log('  Examples:');
@@ -495,7 +495,7 @@ commander
   .action(request.priceVoice.bind(request));
 
 commander
-  .command('price:country <country_id>')
+  .command('price:country <country_code>')
   .alias('pc')
   .description('Gives you the cost of sending an outbound text message to the given country ID.')
   .on('--help', () => {

--- a/src/bin.js
+++ b/src/bin.js
@@ -71,6 +71,7 @@ commander
 commander
   .command('number:buy [number_pattern]')
   .description('Buy a number to use for voice or SMS. If a --country_code is provided then the number_pattern is used to search for a number in the given country.')
+  .alias('numbers:buy')
   .alias('nb')
   .option('-c, --country_code [country_code]', 'the country code')
   .option('--confirm', 'skip confirmation step and directly buy the number' )

--- a/src/bin.js
+++ b/src/bin.js
@@ -69,23 +69,10 @@ commander
 
 // Number Buy
 commander
-  .command('number:buy <number>')
-  .description('Buy a number to use for voice or SMS')
+  .command('number:buy [number_pattern]')
+  .description('Buy a number to use for voice or SMS. If a --country_id is provided then the number_pattern is used to search for a number in the given country.')
   .alias('nb')
-  .option('--confirm', 'skip confirmation step and directly buy the number' )
-  .on('--help', () => {
-    emitter.log('  Examples:');
-    emitter.log(' ');
-    emitter.log('    $ nexmo number:buy 445555555555');
-    emitter.log('    $ nexmo number:buy 31555555555');
-    emitter.log('    $ nexmo number:buy 17136738555');
-    emitter.log(' ');
-  })
-  .action(request.numberBuy.bind(request));
-
-commander
-  .command('numbers:buy [country_code] <number>', null, { noHelp: true })
-  .description('Buy a number to use for voice or SMS')
+  .option('-c, --country_id [country_id]', 'the country code')
   .option('--confirm', 'skip confirmation step and directly buy the number' )
   .on('--help', () => {
     emitter.log('  Examples:');
@@ -96,7 +83,8 @@ commander
     emitter.log(' ');
     emitter.log('  Optionally directly search and buy a number:');
     emitter.log(' ');
-    emitter.log('    $ nexmo number:buy GB 445*');
+    emitter.log('    $ nexmo number:buy 445* -c GB');
+    emitter.log('    $ nexmo number:buy -c US');
     emitter.log(' ');
   })
   .action(request.numberBuy.bind(request));

--- a/src/request.js
+++ b/src/request.js
@@ -37,8 +37,8 @@ class Request {
     this.client.instance().number.getPhonePricing('voice', number, this.response.priceVoice.bind(this.response));
   }
 
-  priceCountry(country_id) {
-    this.client.instance().number.getPricing(country_id, this.response.priceCountry.bind(this.response));
+  priceCountry(country_code) {
+    this.client.instance().number.getPricing(country_code, this.response.priceCountry.bind(this.response));
   }
 
   // Numbers
@@ -71,8 +71,8 @@ class Request {
   }
 
   numberBuy(numberOrPattern, command) {
-    if(command.country_id) {
-      this.numberBuyFromSearch(command.country_id, numberOrPattern, command);
+    if(command.country_code) {
+      this.numberBuyFromSearch(command.country_code, numberOrPattern, command);
     }
     else {
       this.numberBuyFromNumber(numberOrPattern, command);

--- a/src/request.js
+++ b/src/request.js
@@ -70,12 +70,12 @@ class Request {
     this.client.instance().number.search(country_code, options, this.response.numberSearch(flags).bind(this.response));
   }
 
-  numberBuy(first, command) {
-    let args = command.parent.rawArgs.filter(arg => (arg.indexOf('-') == -1 && arg.indexOf('nexmo') == -1 && arg.indexOf('node') == -1));
-    if (args.length == 2) {
-      this.numberBuyFromNumber(args[1], command);
-    } else if (args.length == 3) {
-      this.numberBuyFromPattern(args[1], args[2], command);
+  numberBuy(numberOrPattern, command) {
+    if(command.country_id) {
+      this.numberBuyFromSearch(command.country_id, numberOrPattern, command);
+    }
+    else {
+      this.numberBuyFromNumber(numberOrPattern, command);
     }
   }
 
@@ -88,13 +88,15 @@ class Request {
     });
   }
 
-  numberBuyFromPattern(country_code, pattern, flags) {
+  numberBuyFromSearch(country_code, pattern, flags) {
     let options = { features: ['VOICE'] };
 
-    options.pattern = pattern;
-    options.search_pattern = 1;
-    if (pattern[0] === '*') options.search_pattern = 2;
-    if (pattern.slice(-1) === '*') options.search_pattern = 0;
+    if(pattern) {
+      options.pattern = pattern;
+      options.search_pattern = 1;
+      if (pattern[0] === '*') options.search_pattern = 2;
+      if (pattern.slice(-1) === '*') options.search_pattern = 0;
+    }
 
     this.client.instance().number.search(country_code, options, this.response.numberBuyFromPattern((number) => {
       this.numberBuyFromNumber(number, flags);

--- a/tests/request.js
+++ b/tests/request.js
@@ -216,13 +216,60 @@ describe('Request', () => {
         expect(nexmo.numberInsight.get).to.have.been.calledWith({ level: 'basic', number: '123' });
       }));
 
-      it('should handle search', sinon.test(function() {
+      it('should handle search with a default search_pattern of 1', sinon.test(function() {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        request.numberBuy(null, { parent: { rawArgs: ['nb', 'GB', '123'] } });
-        expect(nexmo.number.search).to.have.been.called;
+        
+        const country_code = 'GB';
+        const pattern = '123';
+        request.numberBuy(null, { parent: { rawArgs: ['nb', country_code, pattern] } });
+        expect(nexmo.number.search).to.have.been.calledWith(
+          country_code,
+          {
+            features: ['VOICE'],
+            pattern: pattern,
+            search_pattern: 1
+          }
+        );
       }));
+      
+      it('should handle search with a search_pattern of 2 when * is the first pattern char', sinon.test(function() {
+        nexmo = {};
+        nexmo.number = sinon.createStubInstance(Number);
+        client.instance.returns(nexmo);
+        
+        const country_code = 'GB';
+        const pattern = '*123';
+        request.numberBuy(null, { parent: { rawArgs: ['nb', country_code, pattern] } });
+        expect(nexmo.number.search).to.have.been.calledWith(
+          country_code,
+          {
+            features: ['VOICE'],
+            pattern: pattern,
+            search_pattern: 2
+          }
+        );
+      }));
+      
+      it('should handle search with a search_pattern of 0 when * is the last pattern char', sinon.test(function() {
+        nexmo = {};
+        nexmo.number = sinon.createStubInstance(Number);
+        client.instance.returns(nexmo);
+        
+        const country_code = 'GB';
+        const pattern = '123*';
+        request.numberBuy(null, { parent: { rawArgs: ['nb', country_code, pattern] } });
+        expect(nexmo.number.search).to.have.been.calledWith(
+          country_code,
+          {
+            features: ['VOICE'],
+            pattern: pattern,
+            search_pattern: 0
+          }
+        );
+      }));
+      
     });
 
     describe('.numberCancel', () => {

--- a/tests/request.js
+++ b/tests/request.js
@@ -223,7 +223,7 @@ describe('Request', () => {
         
         const country_code = 'GB';
         const pattern = '123';
-        request.numberBuy(pattern, { country_id: country_code });
+        request.numberBuy(pattern, { country_code: country_code });
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {
@@ -241,7 +241,7 @@ describe('Request', () => {
         
         const country_code = 'GB';
         const pattern = '*123';
-        request.numberBuy(pattern, { country_id: country_code });
+        request.numberBuy(pattern, { country_code: country_code });
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {
@@ -259,7 +259,7 @@ describe('Request', () => {
         
         const country_code = 'GB';
         const pattern = '123*';
-        request.numberBuy(pattern, { country_id: country_code });
+        request.numberBuy(pattern, { country_code: country_code });
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {
@@ -270,13 +270,13 @@ describe('Request', () => {
         );
       }));
       
-      it('should buy the first number only country_id flag is set', () => {
+      it('should buy the first number only country_code flag is set', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
         
         const country_code = 'GB';
-        request.numberBuy(null, { country_id: country_code });
+        request.numberBuy(null, { country_code: country_code });
         
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,

--- a/tests/request.js
+++ b/tests/request.js
@@ -212,7 +212,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.numberInsight = sinon.createStubInstance(NumberInsight);
         client.instance.returns(nexmo);
-        request.numberBuy(null, { confirm: true, parent: { rawArgs: ['nb', '123'] } });
+        request.numberBuy('123', { confirm: true });
         expect(nexmo.numberInsight.get).to.have.been.calledWith({ level: 'basic', number: '123' });
       }));
 
@@ -223,7 +223,7 @@ describe('Request', () => {
         
         const country_code = 'GB';
         const pattern = '123';
-        request.numberBuy(null, { parent: { rawArgs: ['nb', country_code, pattern] } });
+        request.numberBuy(pattern, { country_id: country_code });
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {
@@ -241,7 +241,7 @@ describe('Request', () => {
         
         const country_code = 'GB';
         const pattern = '*123';
-        request.numberBuy(null, { parent: { rawArgs: ['nb', country_code, pattern] } });
+        request.numberBuy(pattern, { country_id: country_code });
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {
@@ -259,7 +259,7 @@ describe('Request', () => {
         
         const country_code = 'GB';
         const pattern = '123*';
-        request.numberBuy(null, { parent: { rawArgs: ['nb', country_code, pattern] } });
+        request.numberBuy(pattern, { country_id: country_code });
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {
@@ -270,6 +270,21 @@ describe('Request', () => {
         );
       }));
       
+      it('should buy the first number only country_id flag is set', () => {
+        nexmo = {};
+        nexmo.number = sinon.createStubInstance(Number);
+        client.instance.returns(nexmo);
+        
+        const country_code = 'GB';
+        request.numberBuy(null, { country_id: country_code });
+        
+        expect(nexmo.number.search).to.have.been.calledWith(
+          country_code,
+          {
+            features: ['VOICE']
+          }
+        );
+      });
     });
 
     describe('.numberCancel', () => {


### PR DESCRIPTION
This change makes it easier to buy a number quickly and also simplifies the underlying `numberBuy` code.

Usage is now:

```bash
number:buy [number_pattern]
```

If number_pattern is a full number that number will be purchased.

If it’s not a full number and a `--country_id` option is set then a search is performed using `number_pattern` as the pattern.

```bash
number:buy 5 --country_id GB
```

Or, just by the first number for a country:

```bash
number:buy --country_id US
```

`numbers:buy` (plural) has been removed. It threw an exception anyway.