### PR TITLE
Adding clarification where sms --from is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Message price:     0.03330000 EUR
 **Note:** Some carriers (e.g. US and Canadian) do not allow alphanumeric senders. In these cases you must use one of your Nexmo virtual numbers in the `from` parameter. For example:
 
 ```bash
-nexmo sms <destination_number> Hello world! --from <from_number> --confirm
+nexmo sms <to_number> Hello world! --from <from_number> --confirm
 ```
 
 ### Applications

--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ Remaining balance: 26.80110000 EUR
 Message price:     0.03330000 EUR
 ```
 
+**Note:** Some carriers (e.g. US and Canadian) do not allow alphanumeric senders. In these cases you must use one of your Nexmo virtual numbers in the `from` parameter. For example:
+
+```bash
+nexmo sms <destination_number> Hello world! --from <from_number> --confirm
+```
+
 ### Applications
 
 #### List your Applications


### PR DESCRIPTION
the `--from` parameter should be provided in some cases. Adding a note to the README to highlight this. 