### PR TITLE
Prevent error when using 'nexmo account' when not authenticated

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,15 @@ class Config {
     );
   }
 
+  authenticated() {
+    try {
+      fs.readFileSync(this.readFilename(), 'utf-8');
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
   readFilename() {
     let filename = localFile();
     if (fs.existsSync(filename)) {

--- a/src/request.js
+++ b/src/request.js
@@ -18,7 +18,11 @@ class Request {
   }
 
   accountInfo() {
-    this.response.accountInfo(this.config.read());
+    if (this.config.authenticated()) {
+      this.response.accountInfo(null, this.config.read());
+    } else {
+      this.response.accountInfo({ message: 'Not authenticated. Run "nexmo setup <api_key> <api_secret>" to log in.' }, null);
+    }
   }
 
   accountBalance() {

--- a/src/response.js
+++ b/src/response.js
@@ -19,10 +19,11 @@ class Response {
     };
   }
 
-  accountInfo(ini) {
+  accountInfo(error, response) {
+    this.validator.response(error, response);
     this.emitter.log(
-`API Key:    ${ini.credentials.api_key}
-API Secret: ${ini.credentials.api_secret}`
+`API Key:    ${response.credentials.api_key}
+API Secret: ${response.credentials.api_secret}`
     );
   }
 

--- a/tests/request.js
+++ b/tests/request.js
@@ -50,6 +50,7 @@ describe('Request', () => {
     describe('.accountInfo', () => {
       it('should read the credentials', sinon.test(function() {
         nexmo = {};
+        config.authenticated.returns(true);
         request.accountInfo();
         expect(config.read).to.have.been.called;
         expect(response.accountInfo).to.have.been.called;
@@ -220,7 +221,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         const pattern = '123';
         request.numberBuy(pattern, { country_code: country_code });
@@ -233,12 +234,12 @@ describe('Request', () => {
           }
         );
       }));
-      
+
       it('should handle search with a search_pattern of 2 when * is the first pattern char', sinon.test(function() {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         const pattern = '*123';
         request.numberBuy(pattern, { country_code: country_code });
@@ -251,12 +252,12 @@ describe('Request', () => {
           }
         );
       }));
-      
+
       it('should handle search with a search_pattern of 0 when * is the last pattern char', sinon.test(function() {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         const pattern = '123*';
         request.numberBuy(pattern, { country_code: country_code });
@@ -269,15 +270,15 @@ describe('Request', () => {
           }
         );
       }));
-      
+
       it('should buy the first number only country_code flag is set', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         request.numberBuy(null, { country_code: country_code });
-        
+
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {

--- a/tests/response.js
+++ b/tests/response.js
@@ -38,9 +38,10 @@ describe('Response', () => {
 
   describe('.accountInfo', () => {
     it('should emit the result', sinon.test(function() {
-      response.accountInfo({credentials: { 'api_key' : '123', 'api_secret' : '234' }});
+      response.accountInfo(null, {credentials: { 'api_key' : '123', 'api_secret' : '234' }});
       expect(emitter.log).to.have.been.calledWith(`API Key:    123
 API Secret: 234`);
+      expect(validator.response).to.have.been.called;
     }));
   });
 


### PR DESCRIPTION
Closes #85.

Now throws a nice simple warning instead:

```sh
Not authenticated. Run "nexmo setup <api_key> <api_secret>" to log in.
```