### PR TITLE
Prevent error when using 'nexmo account' when not authenticated

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,9 +7,10 @@ class Config {
   }
 
   read() {
-    return ini.parse(
+    this.credentials = ini.parse(
       fs.readFileSync(this.readFilename(), 'utf-8')
     );
+    return this.credentials;
   }
 
   write(data, local=false) {

--- a/src/request.js
+++ b/src/request.js
@@ -18,7 +18,7 @@ class Request {
   }
 
   accountInfo() {
-    this.response.accountInfo(this.config.read());
+    this.response.accountInfo(this.client.instance());
   }
 
   accountBalance() {

--- a/tests/request.js
+++ b/tests/request.js
@@ -49,10 +49,10 @@ describe('Request', () => {
 
     describe('.accountInfo', () => {
       it('should read the credentials', sinon.test(function() {
-        nexmo = {};
+        nexmo = { credentials: 'credentials' };
+        client.instance.returns(nexmo);
         request.accountInfo();
-        expect(config.read).to.have.been.called;
-        expect(response.accountInfo).to.have.been.called;
+        expect(response.accountInfo).to.have.been.calledWith({ credentials: 'credentials' });
       }));
     });
 
@@ -220,7 +220,7 @@ describe('Request', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         const pattern = '123';
         request.numberBuy(pattern, { country_code: country_code });
@@ -233,12 +233,12 @@ describe('Request', () => {
           }
         );
       }));
-      
+
       it('should handle search with a search_pattern of 2 when * is the first pattern char', sinon.test(function() {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         const pattern = '*123';
         request.numberBuy(pattern, { country_code: country_code });
@@ -251,12 +251,12 @@ describe('Request', () => {
           }
         );
       }));
-      
+
       it('should handle search with a search_pattern of 0 when * is the last pattern char', sinon.test(function() {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         const pattern = '123*';
         request.numberBuy(pattern, { country_code: country_code });
@@ -269,15 +269,15 @@ describe('Request', () => {
           }
         );
       }));
-      
+
       it('should buy the first number only country_code flag is set', () => {
         nexmo = {};
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
-        
+
         const country_code = 'GB';
         request.numberBuy(null, { country_code: country_code });
-        
+
         expect(nexmo.number.search).to.have.been.calledWith(
           country_code,
           {


### PR DESCRIPTION
Now throws a nice simple warning instead:

```
Could not read credentials. Please run 'nexmo setup' to setup the CLI. (ENOENT: no such file or directory, open '/Users/cbetta/.nexmorc')
```