### PR TITLE
Improve error catching to match changes in Node library

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -6,8 +6,10 @@ class Validator {
   response(error, response) {
     this.debug(error, response);
 
-    if (error) {
+    if (error && error.message) {
       this.emitter.error(error.message);
+    } else if (error && error['error-code']) {
+      this.emitter.error(error['error-code-label']);
     } else if (response['error-code'] && response['error-code'] !== '200') {
       this.emitter.error(response['error-code-label']);
     } else if (response['status'] && response['status'] !== '0') {


### PR DESCRIPTION
Recent changes in the Node library have caused not all errors to be processed correctly. See nexmo/nexmo-node#78 . While this is being fixed we need to patch the CLI to process this correctly.

Closes #104