### PR TITLE
Bump to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.3][]
+
+* Update methods that required Number Insight checks to operate to accept a static `country_code` flag
+* Change default pagination size for most calls to 100
+* Add `app:numbers` command to look up numbers for an application
+* Remove `--app_id` flag from `jwt:generate`
+
+## [0.3.2][]
+
+*   Update [nexmo-node][] library to **1.1.2**
+*   Better handling for 500 errors
+
 ## [0.3.1][]
 
 *   Update [nexmo-node][] library to **1.1.1**
@@ -129,6 +141,8 @@ List of commands:
     *   `app:show`
     *   `app:delete`
 
+[0.3.2]: https://github.com/Nexmo/nexmo-cli/tree/v0.3.2
+[0.3.1]: https://github.com/Nexmo/nexmo-cli/tree/v0.3.1
 [0.3.0]: https://github.com/Nexmo/nexmo-cli/tree/v0.3.0
 [0.2.0]: https://github.com/Nexmo/nexmo-cli/tree/v0.2.0
 [0.1.0]: https://github.com/Nexmo/nexmo-cli/tree/v0.1.0

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Generate a JWT for your application. Optionally supports extra claims to be pass
 ```
 > nexmo jwt:generate path/to/private.key subject=username iat=1475861732
 [...JWT String...]
-> nexmo jwt:generate path/to/private.key subject=username iat=1475861732 --app_id asdasdas-asdd-2344-2344-asdasdasd345
+> nexmo jwt:generate path/to/private.key subject=username iat=1475861732 application_id=asdasdas-asdd-2344-2344-asdasdasd345
 > JWT: [...JWT String...]
 ```
 

--- a/README.md
+++ b/README.md
@@ -438,6 +438,31 @@ Application deleted
 
 Alias: `nexmo ad`.
 
+#### Show numbers for an application
+
+- Optional flags:
+
+  - `--size` the amount of results to return
+  - `--page` the page of results to return
+
+```
+> nexmo app:numbers asdasdas-asdd-2344-2344-asdasdasd345
+31555555555
+44655555555
+44555555555
+
+> nexmo app:numbers --verbose
+Item 1-3 of 3
+
+msisdn      | country | type       | features  | voiceCallbackType | voiceCallbackValue | moHttpUrl | voiceStatusCallbackUrl
+----------------------------------------------------------------------------------------------------------------------------
+31555555555 | NL      | mobile-lvn | VOICE,SMS | app               | b6d9f957           | undefined | https://example.com
+44655555555 | GB      | mobile-lvn | VOICE,SMS | app               | b6d9f957           | undefined | https://example.com
+44555555555 | GB      | mobile-lvn | SMS       | app               | b6d9f957           | undefined | https://example.com
+```
+
+Alias: `nexmo an` and `nexmo apps:numbers`.
+
 ### Linking
 
 #### Link a number to an app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexmo-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Nexmo Command Line Interface",
   "main": "lib/request.js",
   "scripts": {

--- a/src/bin.js
+++ b/src/bin.js
@@ -133,6 +133,7 @@ commander
   .command('number:cancel <number>')
   .description('Cancel a number you own')
   .option('--confirm', 'skip confirmation step and directly cancel the number' )
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .alias('nc')
   .on('--help', () => {
     emitter.log('  Examples:');
@@ -148,6 +149,7 @@ commander
   .command('numbers:cancel <number>', null, { noHelp: true })
   .description('Cancel a number you own')
   .option('--confirm', 'skip confirmation step and directly cancel the number' )
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -166,6 +168,7 @@ commander
   .option('--voice_callback_type <voice_callback_type>', 'the voice callback type (any of app/sip/tel/vxml)')
   .option('--voice_callback_value <voice_callback_value>', 'the voice callback value based on the voice_callback_type')
   .option('--voice_status_callback <voice_status_callback>', 'a URL to which Nexmo will send a request when the call ends to notify your application')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -181,6 +184,7 @@ commander
   .option('--voice_callback_type <voice_callback_type>', 'the voice callback type (any of app/sip/tel/vxml)')
   .option('--voice_callback_value <voice_callback_value>', 'the voice callback value based on the voice_callback_type')
   .option('--voice_status_callback <voice_status_callback>', 'a URL to which Nexmo will send a request when the call ends to notify your application')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -317,6 +321,7 @@ commander
   .command('link:app <number> <app_id>')
   .alias('la')
   .description('Link a number to an application')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -329,6 +334,7 @@ commander
   .command('link:sms <number> <callback_url>')
   .alias('lsms')
   .description('Link a number to an sms callback URL')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -342,6 +348,7 @@ commander
   .alias('lv')
   .description('Link a number to a vxml callback URL')
   .option('--voice_status_callback <voice_status_callback>', 'a URL to which Nexmo will send a request when the call ends to notify your application.')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -355,6 +362,7 @@ commander
   .alias('lt')
   .description('Link a number to another number')
   .option('--voice_status_callback <voice_status_callback>', 'a URL to which Nexmo will send a request when the call ends to notify your application.')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -368,6 +376,7 @@ commander
   .alias('lsip')
   .description('Link a number to SIP URI')
   .option('--voice_status_callback <voice_status_callback>', 'a URL to which Nexmo will send a request when the call ends to notify your application.')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -381,6 +390,7 @@ commander
 commander
   .command('unlink:app <number>')
   .description('Unlink a number from an application')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -392,6 +402,7 @@ commander
 commander
   .command('unlink:sms <number>')
   .description('Unlink a number from a sms callback URL')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -403,6 +414,7 @@ commander
 commander
   .command('unlink:vxml <number>')
   .description('Unlink a number from a vxml callback URL')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -414,6 +426,7 @@ commander
 commander
   .command('unlink:tel <number>')
   .description('Unlink a number from another number')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -425,6 +438,7 @@ commander
 commander
   .command('unlink:sip <number>')
   .description('Unlink a number from a SIP URI')
+  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');

--- a/src/bin.js
+++ b/src/bin.js
@@ -315,6 +315,23 @@ commander
   .option('--confirm', 'skip confirmation step and directly delete the app' )
   .action(request.applicationDelete.bind(request));
 
+// App numbers
+
+commander
+  .command('app:numbers <app_id>')
+  .description('Show numbers associated to a Nexmo Application')
+  .option('--page <page>', 'the page of results to return')
+  .option('--size <size>', 'the amount of results to return')
+  .alias('an')
+  .action(request.applicationNumbers.bind(request));
+
+commander
+  .command('apps:numbers <app_id>', null, { noHelp: true })
+  .description('Show numbers associated to a Nexmo Application')
+  .option('--page <page>', 'the page of results to return')
+  .option('--size <size>', 'the amount of results to return')
+  .action(request.applicationNumbers.bind(request));
+
 // Create a link
 
 commander
@@ -542,7 +559,7 @@ commander
   .option('-f, --from <from...>', 'the number or name to send the SMS message from (defaults to "Nexmo CLI")', 'Nexmo CLI')
   .description('Send an SMS')
   .action(request.sendSms.bind(request));
-  
+
 commander
   .command('jwt:generate <private_key> [claims...]')
   .option('--app_id <app_id>', 'the application ID to be included in the claim')

--- a/src/bin.js
+++ b/src/bin.js
@@ -562,7 +562,6 @@ commander
 
 commander
   .command('jwt:generate <private_key> [claims...]')
-  .option('--app_id <app_id>', 'the application ID to be included in the claim')
   .description('Generate a JWT (JSON Web Token)')
   .on('--help', () => {
     emitter.log('  Examples:');
@@ -571,7 +570,7 @@ commander
     emitter.log(' ');
     emitter.log('    $ nexmo jwt:generate path/to/private.key subject=username iat=1475861732');
     emitter.log(' ');
-    emitter.log('    $ nexmo jwt:generate path/to/private.key subject=username iat=1475861732 --app_id asdasdas-asdd-2344-2344-asdasdasd345');
+    emitter.log('    $ nexmo jwt:generate path/to/private.key subject=username iat=1475861732 application_id=asdasdas-asdd-2344-2344-asdasdasd345');
     emitter.log(' ');
   })
   .action(request.generateJwt.bind(request));

--- a/src/request.js
+++ b/src/request.js
@@ -44,7 +44,7 @@ class Request {
   // Numbers
 
   numbersList(flags) {
-    let options = {};
+    let options = { size: 100 };
     if (flags.page) { options.index = flags.page; }
     if (flags.size) { options.size = flags.size; }
 
@@ -54,7 +54,7 @@ class Request {
   numberSearch(country_code, flags) {
     country_code = country_code.toUpperCase();
 
-    let options = { features: [] };
+    let options = { features: [], size: 100 };
     if (flags.voice) { options.features.push('VOICE'); }
     if (flags.sms) { options.features.push('SMS'); }
     if (flags.page) { options.index = flags.page; }
@@ -114,7 +114,7 @@ class Request {
   // Applications
 
   applicationsList(flags) {
-    let options = {};
+    let options = { page_size: 100 };
     if (flags.page) { options.index = flags.page; }
     if (flags.size) { options.page_size = flags.size; }
 

--- a/src/request.js
+++ b/src/request.js
@@ -147,6 +147,14 @@ class Request {
     });
   }
 
+  applicationNumbers(app_id, flags) {
+    let options = {};
+    if (flags.page) { options.index = flags.page; }
+    if (flags.size) { options.size = flags.size; }
+
+    this.client.instance().number.get(options, this.response.applicationNumbers(app_id, flags).bind(this.response));
+  }
+
   // links
 
   linkApp(number, app_id, flags) {

--- a/src/response.js
+++ b/src/response.js
@@ -161,6 +161,22 @@ API Secret: ${client.credentials.apiSecret}`
     this.emitter.log('Application deleted');
   }
 
+  applicationNumbers(app_id, flags) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      if (response.numbers && response.numbers.length > 0) {
+        response.numbers = response.numbers.filter((number) => {
+          return number.voiceCallbackValue == app_id;
+        });
+
+        this.emitter.pagination(flags, response);
+        this.emitter.table(response.numbers, ['msisdn'], ['msisdn', 'country', 'type', 'features', 'voiceCallbackType', 'voiceCallbackValue', 'moHttpUrl', 'voiceStatusCallbackUrl']);
+      } else {
+        this.emitter.warn('No numbers');
+      }
+    };
+  }
+
   // links
 
   numberUpdate(error, response) {

--- a/tests/request.js
+++ b/tests/request.js
@@ -410,6 +410,35 @@ describe('Request', () => {
       }));
     });
 
+    describe('.applicationNumbers', () => {
+      it('should call nexmo.number.get', sinon.test(function() {
+        nexmo = {};
+        nexmo.number = sinon.createStubInstance(Number);
+        client.instance.returns(nexmo);
+        response.applicationNumbers.returns(()=>{});
+        request.applicationNumbers('app_id', {});
+        expect(nexmo.number.get).to.have.been.called;
+      }));
+
+      it('should parse a page flag', sinon.test(function() {
+        nexmo = {};
+        nexmo.number = sinon.createStubInstance(Number);
+        client.instance.returns(nexmo);
+        response.applicationNumbers.returns(()=>{});
+        request.applicationNumbers('app_id', { page: 2 });
+        expect(nexmo.number.get).to.have.been.calledWith({ index: 2 });
+      }));
+
+      it('should parse a size flag', sinon.test(function() {
+        nexmo = {};
+        nexmo.number = sinon.createStubInstance(Number);
+        client.instance.returns(nexmo);
+        response.applicationNumbers.returns(()=>{});
+        request.applicationNumbers('app_id', { size: 25 });
+        expect(nexmo.number.get).to.have.been.calledWith({ size: 25 });
+      }));
+    });
+
     describe('.linkApp', () => {
       it('should call the nexmo.number.get({level:"basic"})', sinon.test(function() {
         nexmo = {};

--- a/tests/request.js
+++ b/tests/request.js
@@ -112,6 +112,7 @@ describe('Request', () => {
         response.numbersList.returns(()=>{});
         request.numbersList({});
         expect(nexmo.number.get).to.have.been.called;
+        expect(nexmo.number.get).to.have.been.calledWith({ size: 100 });
       }));
 
       it('should parse a page flag', sinon.test(function() {
@@ -120,7 +121,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numbersList.returns(()=>{});
         request.numbersList({ page: 2 });
-        expect(nexmo.number.get).to.have.been.calledWith({ index: 2 });
+        expect(nexmo.number.get).to.have.been.calledWith({ index: 2, size: 100 });
       }));
 
       it('should parse a size flag', sinon.test(function() {
@@ -140,7 +141,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numberSearch.returns(()=>{});
         request.numberSearch('GB', {});
-        expect(nexmo.number.search).to.have.been.called;
+        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], size: 100 });
       }));
 
       it('should parse a voice flag', sinon.test(function() {
@@ -149,7 +150,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { voice: true });
-        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['VOICE'] });
+        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['VOICE'], size: 100 });
       }));
 
       it('should parse a sms flag', sinon.test(function() {
@@ -158,7 +159,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { sms: true });
-        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['SMS'] });
+        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['SMS'], size: 100 });
       }));
 
       it('should parse both the sms and voice flag', sinon.test(function() {
@@ -167,7 +168,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { sms: true, voice: true });
-        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['VOICE','SMS'] });
+        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: ['VOICE','SMS'], size: 100 });
       }));
 
       it('should parse a page flag', sinon.test(function() {
@@ -176,7 +177,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { page: 2 });
-        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], index: 2 });
+        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], index: 2, size: 100 });
       }));
 
       it('should parse a size flag', sinon.test(function() {
@@ -194,7 +195,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { pattern: '020'});
-        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], pattern: '020', search_pattern: 1 });
+        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], pattern: '020', search_pattern: 1, size: 100 });
       }));
 
       it('should pass the pattern flag with a start-of wildcard', sinon.test(function() {
@@ -203,7 +204,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.numberSearch.returns(()=>{});
         request.numberSearch('GB', { pattern: '*020'});
-        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], pattern: '*020', search_pattern: 2 });
+        expect(nexmo.number.search).to.have.been.calledWith('GB', { features: [], pattern: '*020', search_pattern: 2, size: 100 });
       }));
     });
 
@@ -314,7 +315,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.applicationsList.returns(()=>{});
         request.applicationsList({});
-        expect(nexmo.app.get).to.have.been.called;
+        expect(nexmo.app.get).to.have.been.calledWith({page_size: 100});
       }));
 
       it('should parse a page flag', sinon.test(function() {
@@ -323,7 +324,7 @@ describe('Request', () => {
         client.instance.returns(nexmo);
         response.applicationsList.returns(()=>{});
         request.applicationsList({ page: 2 });
-        expect(nexmo.app.get).to.have.been.calledWith({ index: 2 });
+        expect(nexmo.app.get).to.have.been.calledWith({ index: 2, page_size: 100 });
       }));
 
       it('should parse a size flag', sinon.test(function() {

--- a/tests/request.js
+++ b/tests/request.js
@@ -295,6 +295,16 @@ describe('Request', () => {
         request.numberCancel('123', { confirm: true });
         expect(nexmo.numberInsight.get).to.have.been.called;
       }));
+
+      it('should call nexmo.number.cancel if the country code was forced', sinon.test(function() {
+        nexmo = {};
+        nexmo.number = sinon.createStubInstance(Number);
+        nexmo.response = sinon.createStubInstance(Response);
+        client.instance.returns(nexmo);
+        response.numberCancel.returns(()=>{});
+        request.numberCancel('123', { country_code: 'GB', confirm: true });
+        expect(nexmo.number.cancel).to.have.been.called;
+      }));
     });
 
     describe('.applicationsList', () => {
@@ -594,5 +604,21 @@ describe('Request', () => {
 
     });
 
+    describe('.getCountryCode', () => {
+      it('should return the country code if provided', sinon.test(function() {
+        let callback = sinon.spy();
+        request.getCountryCode('44555666777', { country_code: 'GB' }, callback);
+        expect(callback).to.have.been.calledWith('GB');
+      }));
+
+      it('should call number insight if no country code was provided', sinon.test(function() {
+        nexmo = {};
+        let callback = sinon.spy();
+        nexmo.numberInsight = sinon.createStubInstance(NumberInsight);
+        client.instance.returns(nexmo);
+        request.getCountryCode('44555666777', {}, callback);
+        expect(nexmo.numberInsight.get).to.have.been.calledWith({ level: 'basic', number: '44555666777' });
+      }));
+    });
   });
 });

--- a/tests/response.js
+++ b/tests/response.js
@@ -205,6 +205,23 @@ API Secret: 234`);
     });
   });
 
+  describe('.applicationNumbers', () => {
+    it('should print a list of only the numbers that match', () => {
+      let data = {'count':1,'numbers':[
+        {'country':'ES','msisdn':'34911067000','type':'landline','features':['SMS'], 'voiceCallbackValue':'app_id'},
+        {'country':'ES','msisdn':'34911067000','type':'landline','features':['SMS'], 'voiceCallbackValue':'other_app_id'}
+      ]};
+      response.applicationNumbers('app_id', {})(null, data);
+      expect(validator.response).to.have.been.calledWith(null, data);
+      expect(emitter.table).to.have.been.calledWith([{ country: 'ES', features: ['SMS'], msisdn: '34911067000', type: 'landline', voiceCallbackValue: 'app_id' }], ['msisdn'], ['msisdn', 'country', 'type', 'features', 'voiceCallbackType', 'voiceCallbackValue', 'moHttpUrl', 'voiceStatusCallbackUrl']);
+    });
+
+    it('should warn if no numbers found', () => {
+      response.applicationNumbers({})(null, { numbers: []});
+      expect(emitter.warn).to.have.been.called;
+    });
+  });
+
   describe('.numberUpdate', () => {
     it('should print the response', () => {
       let data = 'response';


### PR DESCRIPTION
* Update methods that required Number Insight checks to operate to accept a static `country_code` flag
* Change default pagination size for most calls to 100
* Add `app:numbers` command to look up numbers for an application
* Remove `--app_id` flag from `jwt:generate`

Closes #120 
Closes #51 
Closes #84 