### PR TITLE
Bump to nexmo-node 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexmo-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Nexmo Command Line Interface",
   "main": "lib/request.js",
   "scripts": {
@@ -49,6 +49,6 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "ini": "^1.3.4",
-    "nexmo": "^1.1.2"
+    "nexmo": "^2.0.1"
   }
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -8,8 +8,8 @@ class Validator {
 
     if (error && error.message) {
       this.emitter.error(error.message);
-    } else if (error && error['error-code']) {
-      this.emitter.error(error['error-code-label']);
+    } else if (error && error.body && error.body['error-code']) {
+      this.emitter.error(error.body['error-code-label']);
     } else if (response['error-code'] && response['error-code'] !== '200') {
       this.emitter.error(response['error-code-label']);
     } else if (response['status'] && response['status'] !== '0') {


### PR DESCRIPTION
Closes #138 

Updates Node library to 2.0.1. Updates error catching to expect new `error.body` object.