### PR TITLE
adding partial app id match for 'nexmo an' #168

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,12 +1472,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1492,17 +1494,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1619,7 +1624,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1631,6 +1637,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1645,6 +1652,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1652,12 +1660,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1676,6 +1686,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1756,7 +1767,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1768,6 +1780,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1889,6 +1902,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/request.js
+++ b/src/request.js
@@ -159,6 +159,7 @@ class Request {
     if (flags.page) { options.index = flags.page; }
     if (flags.size) { options.size = flags.size; }
 
+    app_id = this.client.instance().app.get({}, this.response.searchByPartialAppId(app_id).bind(this.response));
     this.client.instance().number.get(options, this.response.applicationNumbers(app_id, flags).bind(this.response));
   }
 
@@ -341,4 +342,3 @@ let stripPlus = function (number) {
   }
   return number;
 };
-

--- a/src/response.js
+++ b/src/response.js
@@ -138,6 +138,23 @@ API Secret: ${client.credentials.apiSecret}`
     };
   }
 
+  searchByPartialAppId(partialAppId) {
+    return (error, response) => {
+      this.validator.response(error, response);
+      let matches = response._embedded.applications.filter(application => application.id.startsWith(partialAppId));
+      if (matches.length == 0) {
+        this.emitter.warn(`No applications found with ID beginning: ${partialAppId}`);
+      } else if (matches.length > 1) {
+        this.emitter.warn(
+          `Multiple applications found with ID beginning: ${partialAppId}\n` +
+          'Try again with a more specific ID'
+        );
+      } else {
+        return matches[0].id;
+      }
+    };
+  }
+
   applicationCreate(flags) {
     return (error, response) => {
       this.validator.response(error, response);

--- a/tests/request.js
+++ b/tests/request.js
@@ -444,10 +444,24 @@ describe('Request', () => {
     });
 
     describe('.applicationNumbers', () => {
-      it('should call nexmo.number.get', sinon.test(function() {
+      it('should call nexmo.app.get', sinon.test(function () {
         nexmo = {};
+        nexmo.app = sinon.createStubInstance(App);
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.applicationsList.returns(()=>{});
+        response.searchByPartialAppId.returns(()=>{});
+        response.applicationNumbers.returns(()=>{});
+        request.applicationNumbers('app_id', {});
+        expect(nexmo.app.get).to.have.been.calledWith({});
+      }));
+
+      it('should call nexmo.number.get', sinon.test(function() {
+        nexmo = {};
+        nexmo.app = sinon.createStubInstance(App);
+        nexmo.number = sinon.createStubInstance(Number);
+        client.instance.returns(nexmo);
+        response.searchByPartialAppId.returns(()=>{});
         response.applicationNumbers.returns(()=>{});
         request.applicationNumbers('app_id', {});
         expect(nexmo.number.get).to.have.been.called;
@@ -455,8 +469,10 @@ describe('Request', () => {
 
       it('should parse a page flag', sinon.test(function() {
         nexmo = {};
+        nexmo.app = sinon.createStubInstance(App);
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.searchByPartialAppId.returns(()=>{});
         response.applicationNumbers.returns(()=>{});
         request.applicationNumbers('app_id', { page: 2 });
         expect(nexmo.number.get).to.have.been.calledWith({ index: 2 });
@@ -464,8 +480,10 @@ describe('Request', () => {
 
       it('should parse a size flag', sinon.test(function() {
         nexmo = {};
+        nexmo.app = sinon.createStubInstance(App);
         nexmo.number = sinon.createStubInstance(Number);
         client.instance.returns(nexmo);
+        response.searchByPartialAppId.returns(()=>{});
         response.applicationNumbers.returns(()=>{});
         request.applicationNumbers('app_id', { size: 25 });
         expect(nexmo.number.get).to.have.been.calledWith({ size: 25 });

--- a/tests/response.js
+++ b/tests/response.js
@@ -164,6 +164,51 @@ API Secret: 234`);
     });
   });
 
+  describe('.searchByPartialAppId', () => {
+    it('should return a full app_id from a single, partial match', () => {
+      let partialAppId = 'app_';
+      let data = { '_embedded': { 'applications': [{ 'id': 'app_id' }] } };
+      let fullAppId = response.searchByPartialAppId(partialAppId)(null, data);
+
+      expect(validator.response).to.have.been.calledWith(null, data);
+      expect(fullAppId).to.equal(data._embedded.applications[0].id);
+    });
+
+    it('should return a full app_id from a single, partial match from a response with multiple applications', () => {
+      let partialAppId = 'app_';
+      let data = {
+        '_embedded': {
+          'applications': [
+            { 'id': 'not_app_id' }, { 'id': 'app_id' }, { 'id': 'also_not_app_id' }]
+        }
+      };
+      let fullAppId = response.searchByPartialAppId(partialAppId)(null, data);
+
+      expect(validator.response).to.have.been.calledWith(null, data);
+      expect(fullAppId).to.equal(data._embedded.applications[1].id);
+    });
+
+    it('should warn if no match', () => {
+      let partialAppId = 'app_';
+      let data = { '_embedded': { 'applications': [{ 'id': 'not_app_id' }] } };
+      response.searchByPartialAppId(partialAppId)(null, data);
+
+      expect(validator.response).to.have.been.calledWith(null, data);
+      expect(emitter.warn).to.have.been.calledWith(`No applications found with ID beginning: ${partialAppId}`);
+    });
+
+    it('should warn if multiple matches', () => {
+      let partialAppId = 'app_';
+      let data = { '_embedded': { 'applications': [{ 'id': 'app_id_1' }, { 'id': 'app_id_2' }] } };
+      response.searchByPartialAppId(partialAppId)(null, data);
+
+      expect(validator.response).to.have.been.calledWith(null, data);
+      expect(emitter.warn).to.have.been.calledWith(
+        `Multiple applications found with ID beginning: ${partialAppId}\n` +
+        'Try again with a more specific ID');
+    });
+  });
+
   describe('.applicationCreate', () => {
     it('should print the response', () => {
       let method = response.applicationCreate({ keys: {}});


### PR DESCRIPTION
### Summary

Implements partial app_id matching for `nexmo app:numbers` to solve #168 

### Other Information

I wasn't entirely sure how to fit the 2 API calls (one to applicationsList, the other to applicationNumbers) in the existing pattern. I feel like this is the most appropriate way out of the options I was thinking of at the time.
Code reviews/suggestions welcome :+1: 
