### PR TITLE
Updating number:update description to remove ambiguity.

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -176,7 +176,7 @@ commander
 
 commander
   .command('numbers:update <number>')
-  .description('Link a number to an application')
+  .description('Configure the handling of a number')
   .alias('nu')
   .option('--mo_http_url <mo_http_url>', 'used for SMS callbacks')
   .option('--voice_callback_type <voice_callback_type>', 'the voice callback type (any of app/sip/tel/vxml)')
@@ -193,7 +193,7 @@ commander
 
 commander
   .command('number:update <number>', null, { noHelp: true })
-  .description('Link a number to an application')
+  .description('Configure the handling of a number')
   .option('--mo_http_url <mo_http_url>', 'used for SMS callbacks')
   .option('--voice_callback_type <voice_callback_type>', 'the voice callback type (any of app/sip/tel/vxml)')
   .option('--voice_callback_value <voice_callback_value>', 'the voice callback value based on the voice_callback_type')


### PR DESCRIPTION
### Summary

This PR aims to address https://github.com/Nexmo/nexmo-cli/issues/136 by updating the description for `number:update` and `numbers:update` so they're no longer identical to the description for `link:app`.

### Other Information

N/A

Thanks for contributing to the Nexmo CLI!
