### PR TITLE
[WIP] split aliases into duplicate commands

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -111,14 +111,14 @@ commander
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
-    emitter.log('    $ nexmo number:buy 445555555555');
-    emitter.log('    $ nexmo number:buy 31555555555');
-    emitter.log('    $ nexmo number:buy 17136738555');
+    emitter.log('    $ nexmo numbers:buy 445555555555');
+    emitter.log('    $ nexmo numbers:buy 31555555555');
+    emitter.log('    $ nexmo numbers:buy 17136738555');
     emitter.log(' ');
     emitter.log('  Optionally directly search and buy a number:');
     emitter.log(' ');
-    emitter.log('    $ nexmo number:buy 445* -c GB');
-    emitter.log('    $ nexmo number:buy -c US');
+    emitter.log('    $ nexmo numbers:buy 445* -c GB');
+    emitter.log('    $ nexmo numbers:buy -c US');
     emitter.log(' ');
   })
   .action(request.numberBuy.bind(request));

--- a/src/bin.js
+++ b/src/bin.js
@@ -85,8 +85,27 @@ commander
 commander
   .command('number:buy [number_pattern]')
   .description('Buy a number to use for voice or SMS. If a --country_code is provided then the number_pattern is used to search for a number in the given country.')
-  .alias('numbers:buy')
   .alias('nb')
+  .option('-c, --country_code [country_code]', 'the country code')
+  .option('--confirm', 'skip confirmation step and directly buy the number' )
+  .on('--help', () => {
+    emitter.log('  Examples:');
+    emitter.log(' ');
+    emitter.log('    $ nexmo number:buy 445555555555');
+    emitter.log('    $ nexmo number:buy 31555555555');
+    emitter.log('    $ nexmo number:buy 17136738555');
+    emitter.log(' ');
+    emitter.log('  Optionally directly search and buy a number:');
+    emitter.log(' ');
+    emitter.log('    $ nexmo number:buy 445* -c GB');
+    emitter.log('    $ nexmo number:buy -c US');
+    emitter.log(' ');
+  })
+  .action(request.numberBuy.bind(request));
+
+commander
+  .command('numbers:buy [number_pattern]')
+  .description('Buy a number to use for voice or SMS. If a --country_code is provided then the number_pattern is used to search for a number in the given country.')
   .option('-c, --country_code [country_code]', 'the country code')
   .option('--confirm', 'skip confirmation step and directly buy the number' )
   .on('--help', () => {


### PR DESCRIPTION
### Summary

moved `numbers:buy` into a separate command so the alias is not overwritten by `nb`.
This doesn't seem very [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) though and I'm not quite sure how to make sure this doesn't happen since commander silently overwrites the alias. Subclass it? 

What would be the preferred way to handle this? 

### Other Information

partially handles #141 

Thanks for contributing to the Nexmo CLI!
