### PR TITLE
fixes test for windows

### DIFF
--- a/tests/config.js
+++ b/tests/config.js
@@ -4,6 +4,7 @@ import Emitter  from '../src/emitter.js';
 import { expect } from 'chai';
 import sinon      from 'sinon';
 import fs         from 'fs';
+import os from 'os';
 
 describe('Config', () => {
   let emitter;
@@ -43,7 +44,7 @@ api_secret=abc
       let writeFileSync = fs.writeFileSync;
       fs.writeFileSync = function(filename, data){
         expect(filename).to.match(/\/\.nexmorc$/);
-        expect(data.replace(/\r\n/gm, '\n')).to.equal(ini_content);
+        expect(data.replace(new RegExp(os.EOL, 'gm'), '\n')).to.equal(ini_content);
       };
       config.write(credentials);
       fs.writeFileSync = writeFileSync;

--- a/tests/config.js
+++ b/tests/config.js
@@ -15,10 +15,12 @@ describe('Config', () => {
   beforeEach(() => {
     emitter = sinon.createStubInstance(Emitter);
     config = new Config(emitter);
-    ini_content = `[credentials]
-api_key=123
-api_secret=abc
-`;
+    ini_content = [
+      '[credentials]', 
+      'api_key=123', 
+      'api_secret=abc',
+      ''
+    ].join(os.EOL);
     credentials = { credentials: { api_key: '123', api_secret: 'abc'}};
   });
 
@@ -44,7 +46,7 @@ api_secret=abc
       let writeFileSync = fs.writeFileSync;
       fs.writeFileSync = function(filename, data){
         expect(filename).to.match(/\/\.nexmorc$/);
-        expect(data.replace(new RegExp(os.EOL, 'gm'), '\n')).to.equal(ini_content);
+        expect(data).to.equal(ini_content);
       };
       config.write(credentials);
       fs.writeFileSync = writeFileSync;

--- a/tests/config.js
+++ b/tests/config.js
@@ -43,7 +43,7 @@ api_secret=abc
       let writeFileSync = fs.writeFileSync;
       fs.writeFileSync = function(filename, data){
         expect(filename).to.match(/\/\.nexmorc$/);
-        expect(data).to.equal(ini_content);
+        expect(data.replace(/\r\n/gm, '\n')).to.equal(ini_content);
       };
       config.write(credentials);
       fs.writeFileSync = writeFileSync;


### PR DESCRIPTION
### Summary

Due to difference in newline character in windows config write test was failing. So, this PR just replaces `\r\n` with `\n` 
