### PR TITLE
Make TravisCI Run Tests on Multiple Operating Systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the default behavior for line endings
+* text=auto
+* text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - windows
+  - linux
+  - osx
 language: node_js
 node_js:
 - 4

--- a/tests/config.js
+++ b/tests/config.js
@@ -4,6 +4,7 @@ import Emitter  from '../src/emitter.js';
 import { expect } from 'chai';
 import sinon      from 'sinon';
 import fs         from 'fs';
+import os from 'os';
 
 describe('Config', () => {
   let emitter;
@@ -14,10 +15,12 @@ describe('Config', () => {
   beforeEach(() => {
     emitter = sinon.createStubInstance(Emitter);
     config = new Config(emitter);
-    ini_content = `[credentials]
-api_key=123
-api_secret=abc
-`;
+    ini_content = [
+      '[credentials]', 
+      'api_key=123', 
+      'api_secret=abc',
+      ''
+    ].join(os.EOL);
     credentials = { credentials: { api_key: '123', api_secret: 'abc'}};
   });
 


### PR DESCRIPTION
### Summary

As of 11 October 2018, Travis CI now supports Windows build environment. In light of #177 this PR enables multiple OS build environments (Linux, Windows, and MacOS).

The Windows build currently fails because #177 has not yet been applied. Once that PR is merged, the Windows builds should complete successfully.