### PR TITLE
Update README.md - fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Generate a JWT for your application. Optionally supports extra claims to be pass
 
 ## Contributing
 
-This projects is written in ES2015 and compiled using Babel. The source can be found in the `/src` folder, and the build is compiled to the `/lib` folder.
+This project is written in ES2015 and compiled using Babel. The source can be found in the `/src` folder, and the build is compiled to the `/lib` folder.
 
 To add changes fork (if needed) and clone the project.
 


### PR DESCRIPTION
### Summary
Fixed a small typo. `This projects` vs `This project`

### Other Information
Thanks for the opportunity to contribute to open source software! Even though it's a small contribution.