### PR TITLE
Add a dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
-node_modules/
-lib/
-bin*
+# Whitelist
+**
+
+!src/*.js
+!.babelrc
+!.eslintrc.js
+!package.json
+!package-lock.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+lib/
+bin*

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN set -x \
   && npx pkg -t node10-alpine -o nexmo . \
   && chmod +x nexmo
 
+CMD ["nexmo"]
+
 # FROM node:10-alpine@sha256:fcd9b3cb2fb21157899bbdb35d1cdf3d6acffcd91ad48c1af5cb62c22d2d05b1 \
 #   AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN set -x \
   && npm cache clean --force
 
 COPY .babelrc .eslintrc.js ./
-COPY src/ ./src
+
+CMD ["npm", "run", "watch:test"]
 
 ################################
 # Developement image stops here
@@ -19,6 +20,8 @@ COPY src/ ./src
 
 # STAGE build: Build environment
 FROM dev AS build
+
+COPY ./src ./src
 
 RUN npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# STAGE dev: Development environment
+FROM node:10-alpine@sha256:fcd9b3cb2fb21157899bbdb35d1cdf3d6acffcd91ad48c1af5cb62c22d2d05b1 \
+  AS dev
+
+WORKDIR /nexmo
+
+COPY package.json package-lock.json ./
+
+RUN set -x \
+  && npm ci \
+  && npm cache clean --force
+
+COPY .babelrc .eslintrc.js ./
+COPY src/ ./src
+
+################################
+# Developement image stops here
+# use '--target dev' on build to break here
+
+# STAGE build: Build environment
+FROM dev AS build
+
+RUN npm run build
+
+CMD ["node", "lib/bin.js"]
+
+# STAGE package: Package environment
+FROM build AS package
+
+RUN set -x \
+  && npx pkg -t node10-alpine -o nexmo . \
+  && chmod +x nexmo
+
+# FROM node:10-alpine@sha256:fcd9b3cb2fb21157899bbdb35d1cdf3d6acffcd91ad48c1af5cb62c22d2d05b1 \
+#   AS runtime
+
+# WORKDIR /nexmo
+
+# COPY --from=build /nexmo/package.json ./
+# COPY --from=build /nexmo/node_modules ./node_modules
+# COPY --from=build /nexmo/lib ./lib
+
+# ENTRYPOINT ["node", "lib/bin.js"]
+
+# STAGE runtime: Production environment
+FROM alpine:3.8@sha256:621c2f39f8133acb8e64023a94dbdf0d5ca81896102b9e57c0dc184cadaf5528 \
+  AS runtime
+
+RUN apk add --no-cache libstdc++
+
+COPY --from=package /nexmo/nexmo /usr/bin/nexmo
+
+ENTRYPOINT ["/usr/bin/nexmo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,17 +36,6 @@ RUN set -x \
 
 CMD ["nexmo"]
 
-# FROM node:10-alpine@sha256:fcd9b3cb2fb21157899bbdb35d1cdf3d6acffcd91ad48c1af5cb62c22d2d05b1 \
-#   AS runtime
-
-# WORKDIR /nexmo
-
-# COPY --from=build /nexmo/package.json ./
-# COPY --from=build /nexmo/node_modules ./node_modules
-# COPY --from=build /nexmo/lib ./lib
-
-# ENTRYPOINT ["node", "lib/bin.js"]
-
 # STAGE runtime: Production environment
 FROM alpine:3.8@sha256:621c2f39f8133acb8e64023a94dbdf0d5ca81896102b9e57c0dc184cadaf5528 \
   AS runtime

--- a/README.md
+++ b/README.md
@@ -602,6 +602,17 @@ npm run watch:test # to watch for changes and run tests
 
 You can run the `nexmo` command with the `--debug / -d` flag to get extra debug info from the underlying Node library.
 
+You can also use docker, no dependencies are needed but `docker`.
+```sh
+docker build --target dev -t nexmo:dev .
+
+alias nexmodev='mkdir -p lib; docker run --rm -it -u "$(id -u):$(id -g)" -v $PWD/src:/nexmo/src -v $PWD/tests:/nexmo/tests -v $PWD/lib:/nexmo/lib nexmo:dev npm run'
+
+nexmodev build
+nexmodev watch:test
+nexmodev any-npm-script
+```
+
 # License
 
 This library is released under the [MIT License][license]


### PR DESCRIPTION
### Summary

Add a dockerfile for using/building nexmo-cli

Final runtime image size is `25 MB` compressed
It's available to test on the docker hub: [zadki3l/nexmo](https://hub.docker.com/r/zadki3l/nexmo/tags/)

Try it now with: 
```sh
docker run --rm -it zadki3l/nexmo
```

### Other Information

This dockerfile leverage multiple stages builds:
- `dev`: install dependencies
- `build`: copy project files, build node release code and clean deps
- `runtime`: final production image with built source

I recommend to append `-u "$(id -u):$(id -g)"` to the `docker run` command to keep permissions clean.

Usage
```sh
# Build the dev image
docker build -t nexmo:dev --target dev .
# Build the runtime final image
docker build -t nexmo .

# Run dev image (default to `watch:test` script)
docker run --rm -it -u "$(id -u):$(id -g)" -v $PWD/src:/nexmo/src -v $PWD/tests:/nexmo/tests nexmo:dev
# Run dev image (`build` to external folder)
mkdir -p lib
docker run --rm -it -u "$(id -u):$(id -g)" -v $PWD/src:/nexmo/src -v $PWD/lib:/nexmo/lib nexmo:dev npm run build

# Handy dev alias (run from repo folder)
alias nexmo-dev="mkdir -p $PWD/lib; docker run --rm -it -u '$(id -u):$(id -g)' -v $PWD/src:/nexmo/src -v $PWD/tests:/nexmo/tests -v $PWD/lib:/nexmo/lib nexmo:dev npm run"
# and then:
nexmo-dev build
nexmo-dev watch:test
nexmo-dev any-npm-script

# Run prod image (`nexmo-cli -V`)
docker run --rm -it nexmo -V

# Handy production alias
# assuming you have a $HOME/.nexmorc file
# create it with `touch $HOME/.nexmorc` before running this
alias nexmo="docker run --rm -u '$(id -u):$(id -g)' -v $HOME/.nexmorc:/.nexmorc -it nexmo"
# and then:
nexmo
nexmo setup XX XX
nexmo account
```

Currently `prepublish` step fail in the docker image (don't know why), will need #187 later.