### PR TITLE
Remove vxml cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,18 +512,6 @@ Number updated
 
 Alias: `nexmo lsms`
 
-#### Link a number to a Voice XML callback URL
-
-```bash
-> nexmo link:vxml 12057200555 http://example.com/callback
-Number updated
-
-> nexmo unlink:vxml 12057200555
-Number updated
-```
-
-Alias: `nexmo lv`
-
 #### Link a number to SIP URI
 
 ```bash

--- a/src/bin.js
+++ b/src/bin.js
@@ -394,20 +394,6 @@ commander
   .action(request.linkSms.bind(request));
 
 commander
-  .command('link:vxml <number> <callback_url>')
-  .alias('lv')
-  .description('Link a number to a vxml callback URL')
-  .option('--voice_status_callback <voice_status_callback>', 'a URL to which Nexmo will send a request when the call ends to notify your application.')
-  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
-  .on('--help', () => {
-    emitter.log('  Examples:');
-    emitter.log(' ');
-    emitter.log('    $ nexmo link:vxml 445555555555 http://example.com/callback');
-    emitter.log(' ');
-  })
-  .action(request.linkVxml.bind(request));
-
-commander
   .command('link:tel <number> <other_number>')
   .alias('lt')
   .description('Link a number to another number')
@@ -460,18 +446,6 @@ commander
     emitter.log(' ');
   })
   .action(request.unlinkSms.bind(request));
-
-commander
-  .command('unlink:vxml <number>')
-  .description('Unlink a number from a vxml callback URL')
-  .option('-c, --country_code [country_code]', 'manually provide the country code, overriding a dynamic lookup')
-  .on('--help', () => {
-    emitter.log('  Examples:');
-    emitter.log(' ');
-    emitter.log('    $ nexmo unlink:vxml 445555555555');
-    emitter.log(' ');
-  })
-  .action(request.unlinkVxml.bind(request));
 
 commander
   .command('unlink:tel <number>')

--- a/src/request.js
+++ b/src/request.js
@@ -180,10 +180,6 @@ class Request {
     this._link(number, flags, null, 'sip', sip_uri, flags.voice_status_callback);
   }
 
-  linkVxml(number, calback_url, flags) {
-    this._link(number, flags, null, 'vxml', calback_url, flags.voice_status_callback);
-  }
-
   unlinkApp(number, flags) {
     this._link(number, flags, null, 'app');
   }
@@ -198,10 +194,6 @@ class Request {
 
   unlinkSip(number, flags) {
     this._link(number, flags, null, 'sip');
-  }
-
-  unlinkVxml(number, flags) {
-    this._link(number, flags, null, 'vxml');
   }
 
   numberUpdate(number, flags) {

--- a/tests/request.js
+++ b/tests/request.js
@@ -533,26 +533,6 @@ describe('Request', () => {
         expect(nexmo.numberInsight.get).to.have.been.calledWithMatch({level:'basic'});
       }));
 
-      describe('.linkVxml', () => {
-        it('should call nexmo.numberInsight.get', test(function() {
-          nexmo = {};
-          nexmo.numberInsight = sinon.createStubInstance(NumberInsight);
-          client.instance.returns(nexmo);
-          request.linkVxml('123', 'abc', {});
-          expect(nexmo.numberInsight.get).to.have.been.calledWithMatch({level:'basic'});
-        }));
-      });
-
-      describe('.unlinkVxml', () => {
-        it('should call nexmo.numberInsight.get', test(function() {
-          nexmo = {};
-          nexmo.numberInsight = sinon.createStubInstance(NumberInsight);
-          client.instance.returns(nexmo);
-          request.unlinkVxml('123');
-          expect(nexmo.numberInsight.get).to.have.been.calledWithMatch({level:'basic'});
-        }));
-      });
-
       describe('.linkSip', () => {
         it('should call nexmo.numberInsight.get', test(function() {
           nexmo = {};


### PR DESCRIPTION
Fixes #159: Remove vxml

### Summary

With the shutdown of the call API, the `link:vxml` and `unlink:vxml` commands can be removed as they are no longer used.

Note that this information might be referenced in other areas, ie. the verbose numbers list screen, but this is OK as users may want to see that a number is still linked to vxml in order to identify changes.
