### PR TITLE
Split .eslintrc.js into two

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
     "env": {
         "es6": true,
         "node": true,
-        "mocha": true,
     },
     "extends": "eslint:recommended",
     "parserOptions": {

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  "env": {
+      "mocha": true,
+  },
+};


### PR DESCRIPTION
So that mocha globals are only permitted within test code, and not source code.
