### PR TITLE
Read API Key and Secret from Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ npm install nexmo-cli -g
 
 *Note: you may need root/admin privileges to install the CLI globally.*
 
-After installation, set up the CLI with your [Nexmo](https://dashboard.nexmo.com/settings) API key and secret:
+By default, the CLI will read your [Nexmo](https://dashboard.nexmo.com/settings) API key and secret from the `NEXMO_API_KEY` and `NEXMO_API_SECRET` environment variables. For example, to get your balance:
+
+```bash
+NEXMO_API_KEY=1234 NEXMO_API_SECRET=abcd nexmo balance
+```
+
+Alternatively, you can save your API key and secret by using the following command:
 
 ```bash
 > nexmo setup <api_key> <api_secret>

--- a/src/config.js
+++ b/src/config.js
@@ -7,9 +7,21 @@ class Config {
   }
 
   read() {
-    this.credentials = ini.parse(
-      fs.readFileSync(this.readFilename(), 'utf-8')
-    );
+    const envApiKey = process.env.NEXMO_API_KEY;
+    const envApiSecret = process.env.NEXMO_API_SECRET;
+
+    if (envApiKey && envApiSecret) {
+      this.credentials = {
+        'credentials': {
+          'api_key': envApiKey,
+          'api_secret': envApiSecret
+        }
+      };
+    } else {
+      this.credentials = ini.parse(
+        fs.readFileSync(this.readFilename(), 'utf-8')
+      );
+    }
     return this.credentials;
   }
 

--- a/tests/config.js
+++ b/tests/config.js
@@ -39,6 +39,13 @@ describe('Config', () => {
       expect(data).to.eql(credentials);
       fs.readFileSync = readFileSync;
     });
+    it('should read from the environment', () => {
+      process.env.NEXMO_API_KEY = '123';
+      process.env.NEXMO_API_SECRET = 'abc';
+
+      let data = config.read();
+      expect(data).to.eql(credentials);
+    });
   });
 
   describe('.write', () => {


### PR DESCRIPTION
### Summary

This PR updates the CLI to look for `NEXMO_API_KEY` and `NEXMO_API_SECRET` environment variables to load the configuration before looking to see if a file has been specified.

The motivation for this was in utilizing the CLI in automation tasks (such as GH Actions) required calling:

```
nexmo setup ${NEXMO_API_KEY} ${NEXMO_API_SECRET}
nexmo sms ...
```

This allows for the environment to be used as follows:

```
NEXMO_API_KEY=1234 NEXMO_API_SECRET=abcd nexmo sms...
```

I was originally going to look into `--api-key` and `--api-secret` flags, but I wasn't sure how to add those globally. If there's an easier way to go about doing it, please feel free to reject the PR and I will look into the alternatives.

### Other Information

I chose to allow the environment to override the file. This is also useful when testing things using multiple accounts because the environment can be changed at runtime without needing to use a local `.nexmorc` or modifying an existing `.nexmorc`.
