### PR TITLE
Update README.md (grammatical mistake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Alias: `nexmo nb` and `nexmo numbers:buy`.
 
 ```bash
 > nexmo number:cancel 12069396555
-This is operation can not be reversed.
+This operation can not be reversed.
 
 Please type "confirm" to continue: confirm
 


### PR DESCRIPTION
### Summar
There was a grammatical mistake in **Cancelling a number** section. 

### Other Information
> 
It said
`This is operation can not be reversed`

Changed it to
`This operation can not be reversed`