### PR TITLE
Added commands to gracefully report account information

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,15 @@ Alias: `nexmo s`.
 ```bash
 > nexmo account
 API Key:    <api_key>
-API Secret: <api_secret>
+
+> nexmo account:key
+<api_key>
+
+> nexmo account:secret
+<api_secret>
 ```
+
+Alias: `nexmo a`.
 
 #### Account balance
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Alias: `nexmo s`.
 ```bash
 > nexmo account
 API Key:    <api_key>
+API Secret: <api_secret>
 
 > nexmo account:key
 <api_key>

--- a/src/bin.js
+++ b/src/bin.js
@@ -48,6 +48,16 @@ commander
   .action(request.accountInfo.bind(request));
 
 commander
+  .command('account:key')
+  .description('Your API key')
+  .action(request.accountKey.bind(request));
+
+commander
+  .command('account:secret')
+  .description('Your API secret')
+  .action(request.accountSecret.bind(request));
+
+commander
   .command('balance')
   .description('Current account balance')
   .alias('b')

--- a/src/request.js
+++ b/src/request.js
@@ -21,6 +21,14 @@ class Request {
     this.response.accountInfo(this.client.instance());
   }
 
+  accountKey() {
+    this.response.accountKey(this.client.instance());
+  }
+
+  accountSecret() {
+    this.response.accountSecret(this.client.instance());
+  }
+
   accountBalance() {
     this.client.instance().account.checkBalance(this.response.accountBalance.bind(this.response));
   }

--- a/src/response.js
+++ b/src/response.js
@@ -22,7 +22,7 @@ class Response {
   accountInfo(client) {
     this.emitter.log(
       `API Key:    ${client.credentials.apiKey}
-`
+API Secret: ${client.credentials.apiSecret}`
     );
   }
 

--- a/src/response.js
+++ b/src/response.js
@@ -22,7 +22,21 @@ class Response {
   accountInfo(client) {
     this.emitter.log(
       `API Key:    ${client.credentials.apiKey}
-API Secret: ${client.credentials.apiSecret}`
+`
+    );
+  }
+
+  accountKey(client) {
+    this.emitter.log(
+      `${client.credentials.apiKey}
+`
+    );
+  }
+
+  accountSecret(client) {
+    this.emitter.log(
+      `${client.credentials.apiSecret}
+`
     );
   }
 

--- a/tests/response.js
+++ b/tests/response.js
@@ -42,7 +42,23 @@ describe('Response', () => {
     it('should emit the result', test(function() {
       response.accountInfo({credentials: { 'apiKey' : '123', 'apiSecret' : '234' }});
       expect(emitter.log).to.have.been.calledWith(`API Key:    123
-API Secret: 234`);
+`);
+    }));
+  });
+
+  describe('.accountKey', () => {
+    it('should emit the result', test(function() {
+      response.accountKey({credentials: { 'apiKey' : '123', 'apiSecret' : '234' }});
+      expect(emitter.log).to.have.been.calledWith(`123
+`);
+    }));
+  });
+
+  describe('.accountSecret', () => {
+    it('should emit the result', test(function() {
+      response.accountSecret({credentials: { 'apiKey' : '123', 'apiSecret' : '234' }});
+      expect(emitter.log).to.have.been.calledWith(`234
+`);
     }));
   });
 

--- a/tests/response.js
+++ b/tests/response.js
@@ -42,7 +42,7 @@ describe('Response', () => {
     it('should emit the result', test(function() {
       response.accountInfo({credentials: { 'apiKey' : '123', 'apiSecret' : '234' }});
       expect(emitter.log).to.have.been.calledWith(`API Key:    123
-`);
+API Secret: 234`);
     }));
   });
 


### PR DESCRIPTION
### Summary

Tries to partly address #223. Added missing alias in `README.md` for the `account` command. The API key and secret can be reported separately using `nexmo account:key` and `nexmo account:secret` with the contributions in this PR. Added test cases to handle the new commands.
