### PR TITLE
Use consistent grammar for Help printouts

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -29,9 +29,9 @@ const suggestCommands = (cmd) => {
 
 commander
   .version(pckg.version)
-  .option('-q, --quiet', 'disables all logging except for errors', emitter.quiet.bind(emitter))
-  .option('-v, --verbose', 'enables more rich output for certain commands', emitter.verbose.bind(emitter))
-  .option('-d, --debug', 'enables nexmo library to output debug statements', emitter.debug.bind(emitter));
+  .option('-q, --quiet', 'Disables all logging except for errors', emitter.quiet.bind(emitter))
+  .option('-v, --verbose', 'Enables more rich output for certain commands', emitter.verbose.bind(emitter))
+  .option('-d, --debug', 'Enables Nexmo library to output debug statements', emitter.debug.bind(emitter));
 
 // account level
 commander
@@ -560,7 +560,7 @@ commander
 commander
   .command('price:sms <number>')
   .alias('ps')
-  .description('Gives you the cost of sending an outbound text to a number.')
+  .description('Get the cost of sending an outbound text to a number.')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -572,7 +572,7 @@ commander
 commander
   .command('price:voice <number>')
   .alias('pv')
-  .description('Gives you the cost of making an outbound call to a number.')
+  .description('Get the the cost of making an outbound call to a number.')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');
@@ -584,7 +584,7 @@ commander
 commander
   .command('price:country <country_code>')
   .alias('pc')
-  .description('Gives you the cost of sending an outbound text message to the given country ID.')
+  .description('Get the the cost of sending an outbound text message to the given country ID.')
   .on('--help', () => {
     emitter.log('  Examples:');
     emitter.log(' ');


### PR DESCRIPTION
### Summary
Use consistent grammar for Help printouts

Currently - this thie printout:
```
  insight:basic|ib <number>                                         Get details about this number
  insight:standard|is [options] <number>                            Get more details about this number like the current carrier. This operation will incur a fee.
  insight:advanced|ia [options] <number>                            Get more details about this number like the roaming status and current country of the phone. This operation will incur a fee.
  price:sms|ps <number>                                             Gives you the cost of sending an outbound text to a number.
  price:voice|pv <number>                                           Gives you the cost of making an outbound call to a number.
  price:country|pc <country_code>                                   Gives you the cost of sending an outbound text message to the given country ID.
```

This is inconsistent - `Get` vs `Gives` -- I've alligned all to `Get`

### Other Information

