### PR TITLE
feat: allow for api key/secret as arg for sms

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -599,6 +599,8 @@ commander
   .command('sms <to> <text...>')
   .option('--confirm', 'skip confirmation step and directly send the message' )
   .option('-f, --from <from...>', 'the number or name to send the SMS message from (defaults to "Nexmo CLI")', 'Nexmo CLI')
+  .option('--api-key <api_key>', 'the api key (for not logged-in users)')
+  .option('--api-secret <api_secret>', 'the api secret (for not logged-in users)')
   .description('Send an SMS')
   .action(request.sendSms.bind(request));
 

--- a/src/request.js
+++ b/src/request.js
@@ -259,6 +259,9 @@ class Request {
 
   sendSms(to, text, flags) {
     confirm('This operation will charge your account.', this.response.emitter, flags, () => {
+      if(flags.apiKey && flags.apiSecret){
+        this._verifyCredentials(flags.apiKey, flags.apiSecret, this.response.accountSetup(this.config, flags.apiKey, flags.apiSecret, flags));
+      }
       this.client.instance().message.sendSms(flags.from, to, text.join(' '), this.response.sendSms.bind(this.response));
     });
   }


### PR DESCRIPTION
### Summary

Want to include API key/secret as arguments #86 

### Other Information

Not sure if this works, someone please verify!

Thanks for contributing to the Nexmo CLI!
