### PR TITLE
Fixing the Build Failure for Coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1508,9 +1508,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000903",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000903.tgz",
-      "integrity": "sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g==",
+      "version": "1.0.30001153",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001153.tgz",
+      "integrity": "sha512-qv14w7kWwm2IW7DBvAKWlCqGTmV2XxNtSejJBVplwRjhkohHuhRUpeSlPjtu9erru0+A12zCDUiSmvx/AcqVRA==",
       "dev": true
     },
     "caseless": {

--- a/tests/response.js
+++ b/tests/response.js
@@ -47,18 +47,21 @@ API Secret: 234`);
   });
 
   describe('.accountKey', () => {
-    it('should emit the result', test(function() {
-      response.accountKey({credentials: { 'apiKey' : '123', 'apiSecret' : '234' }});
-      expect(emitter.log).to.have.been.calledWith(`123
-`);
-    }));
+    it(
+      'should emit the result',
+      test(function () {
+        response.accountKey({
+          credentials: { apiKey: '123', apiSecret: '234' },
+        });
+        expect(emitter.log).to.have.been.calledWith('123');
+      })
+    );
   });
 
   describe('.accountSecret', () => {
     it('should emit the result', test(function() {
       response.accountSecret({credentials: { 'apiKey' : '123', 'apiSecret' : '234' }});
-      expect(emitter.log).to.have.been.calledWith(`234
-`);
+      expect(emitter.log).to.have.been.calledWith('234');
     }));
   });
 


### PR DESCRIPTION
### Summary

We have build failures on the master branch where even though a PR built successfully, `npm run coverage` fails. I can also replicate this locally.

So far, this PR includes an update to caniuse-lite since that also outputs errors, but that didn't fix the overall coverage problem.
